### PR TITLE
Bracket Update

### DIFF
--- a/CK3toEU4/Source/EU4World/Output/outProvince.cpp
+++ b/CK3toEU4/Source/EU4World/Output/outProvince.cpp
@@ -90,5 +90,7 @@ std::ostream& EU4::operator<<(std::ostream& output, const Province& province)
 		output << "unrest = " << province.details.unrest << "\n";
 	if (province.details.nationalism)
 		output << "add_nationalism = " << province.details.nationalism << "\n";
+	if (!province.details.datedInfo.empty() && !province.getSourceProvince())
+		output << province.details.datedInfo;
 	return output;
 }

--- a/CK3toEU4/Source/EU4World/Province/ProvinceDetails.cpp
+++ b/CK3toEU4/Source/EU4World/Province/ProvinceDetails.cpp
@@ -175,6 +175,14 @@ void EU4::ProvinceDetails::registerKeys()
 		const commonItems::singleString effectStr(theStream);
 		vaisyasBurghers = effectStr.getString() == "yes";
 	});
+	registerKeyword("1441.1.1", [this](const std::string& unused, std::istream& theStream) {
+		const commonItems::singleString effectStr(theStream);
+		datedInfo = effectStr.getString();
+	});
+	registerKeyword("1444.1.1", [this](const std::string& unused, std::istream& theStream) {
+		const commonItems::singleString effectStr(theStream);
+		datedInfo = effectStr.getString();
+	});	
 	registerRegex(R"(\d+.\d+.\d+)", commonItems::ignoreItem);
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }

--- a/CK3toEU4/Source/EU4World/Province/ProvinceDetails.cpp
+++ b/CK3toEU4/Source/EU4World/Province/ProvinceDetails.cpp
@@ -175,6 +175,8 @@ void EU4::ProvinceDetails::registerKeys()
 		const commonItems::singleString effectStr(theStream);
 		vaisyasBurghers = effectStr.getString() == "yes";
 	});
+	// These two hard overrides are necessary for Palembang and similar countries outside CK scope that are assigned ownership in a 1444 history block instead directly.
+	// Without us replicating the 1441/1444 block they'd remain uncolonized in any conversion.
 	registerKeyword("1441.1.1", [this](const std::string& unused, std::istream& theStream) {
 		const commonItems::singleString effectStr(theStream);
 		datedInfo = effectStr.getString();

--- a/CK3toEU4/Source/EU4World/Province/ProvinceDetails.h
+++ b/CK3toEU4/Source/EU4World/Province/ProvinceDetails.h
@@ -46,6 +46,7 @@ class ProvinceDetails: commonItems::parser
 	std::string religion;
 	std::string tradeGoods;
 	std::string estate;
+	std::string datedInfo;
 	std::set<std::string> cores;
 	std::set<std::string> discoveredBy;
 	std::set<std::string> latentGoods;


### PR DESCRIPTION
- Updated code to account for things set with 1444.1.1 = { or 1441.1.1 = {
Only applies to provinces outside of CK scope.