### PR TITLE
version rework

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,6 +57,7 @@ jobs:
     - name: Custom steps
       run: |
        git submodule update --init --recursive
+       sudo apt-get install libcurl4-openssl-dev
        mkdir $HOME/usr
        export PATH="$HOME/usr/bin:$PATH"
        wget https://cmake.org/files/v3.17/cmake-3.17.2-Linux-x86_64.sh
@@ -66,14 +67,14 @@ jobs:
        sudo apt-add-repository 'deb https://repos.codelite.org/wx3.1.3/ubuntu/ bionic universe'
        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
        sudo apt-get update
-       sudo apt-get install gcc-10 g++-10
+       sudo apt-get install gcc-11 g++-11
        sudo apt-get install libwxbase3.1-0-unofficial3 libwxbase3.1unofficial3-dev libwxgtk3.1-0-unofficial3 libwxgtk3.1unofficial3-dev wx3.1-headers wx-common
-       # Link gcc-10 and g++-10 to their standard commands
-       sudo ln -s /usr/bin/gcc-10 /usr/local/bin/gcc
-       sudo ln -s /usr/bin/g++-10 /usr/local/bin/g++
+       # Link gcc-11 and g++-11 to their standard commands
+       sudo ln -s /usr/bin/gcc-11 /usr/local/bin/gcc
+       sudo ln -s /usr/bin/g++-11 /usr/local/bin/g++
        # Export CC and CXX to tell cmake which compiler to use
-       export CC=/usr/bin/gcc-10
-       export CXX=/usr/bin/g++-10
+       export CC=/usr/bin/gcc-11
+       export CXX=/usr/bin/g++-11
        # Check versions of gcc, g++ and cmake
        gcc -v && g++ -v && cmake --version
        # Run your build commands next

--- a/CK3ToEU4Tests/MapperTests/ConverterVersion/ConverterVersionTests.cpp
+++ b/CK3ToEU4Tests/MapperTests/ConverterVersion/ConverterVersionTests.cpp
@@ -1,14 +1,12 @@
 #include "../../CK3toEU4/Source/Mappers/ConverterVersion/ConverterVersion.h"
 #include "gtest/gtest.h"
-#include <sstream>
 
-TEST(Mappers_ConverterVersionTests, AllItemsDefaultToEmpty)
+TEST(Mappers_ConverterVersionTests, PrimitivesDefaultToEmpty)
 {
 	std::stringstream input;
-	mappers::ConverterVersion version(input);
+	const mappers::ConverterVersion version(input);
 
 	EXPECT_TRUE(version.getName().empty());
-	EXPECT_TRUE(version.getDescription().empty());
 	EXPECT_TRUE(version.getVersion().empty());
 }
 
@@ -16,7 +14,7 @@ TEST(Mappers_ConverterVersionTests, NameCanBeSet)
 {
 	std::stringstream input;
 	input << "name = \"Test Name\"";
-	mappers::ConverterVersion version(input);
+	const mappers::ConverterVersion version(input);
 
 	EXPECT_EQ("Test Name", version.getName());
 }
@@ -25,19 +23,35 @@ TEST(Mappers_ConverterVersionTests, VersionCanBeSet)
 {
 	std::stringstream input;
 	input << "version = \"5.4-Test\"";
-	mappers::ConverterVersion version(input);
-
-	std::stringstream output;
-	output << version;
+	const mappers::ConverterVersion version(input);
 
 	EXPECT_EQ("5.4-Test", version.getVersion());
 }
 
-TEST(Mappers_ConverterVersionTests, DescriptionCanBeSet)
+TEST(Mappers_ConverterVersionTests, DescriptionCanBeConstructed)
 {
 	std::stringstream input;
-	input << "descriptionLine = \"test description\"";
-	mappers::ConverterVersion version(input);
+	input << "source = \"CK3\"\n";
+	input << "target = \"EU4\"\n";
+	input << "minSource = \"1.3\"\n";
+	input << "maxSource = \"1.4\"\n";
+	input << "minTarget = \"1.30.6\"\n";
+	input << "maxTarget = \"1.31.4\"\n";
+	const mappers::ConverterVersion version(input);
 
-	EXPECT_EQ("test description", version.getDescription());
+	EXPECT_EQ("Compatible with CK3 [v1.3-v1.4] and EU4 [v1.30.6-v1.31.4]", version.getDescription());
+}
+
+TEST(Mappers_ConverterVersionTests, DescriptionDoesNotDuplicateVersions)
+{
+	std::stringstream input;
+	input << "source = \"CK3\"\n";
+	input << "target = \"EU4\"\n";
+	input << "minSource = \"1.3\"\n";
+	input << "maxSource = \"1.3\"\n";
+	input << "minTarget = \"1.31\"\n";
+	input << "maxTarget = \"1.31\"\n";
+	const mappers::ConverterVersion version(input);
+
+	EXPECT_EQ("Compatible with CK3 [v1.3] and EU4 [v1.31]", version.getDescription());
 }

--- a/CK3toEU4/Data_Files/configurables/version.txt
+++ b/CK3toEU4/Data_Files/configurables/version.txt
@@ -2,4 +2,9 @@
 
 version = "0.7"
 name = "Gayomarthian"
-descriptionLine = "Compatible with CK3 1.3/1.4 and EU4 1.31"
+source = "CK3"
+minSource = "1.3"
+maxSource = "1.4"
+target = "EU4"
+minTarget = "1.31"
+maxTarget = "1.31.4"

--- a/CK3toEU4/Source/CK3ToEU4Converter.cpp
+++ b/CK3toEU4/Source/CK3ToEU4Converter.cpp
@@ -7,8 +7,8 @@
 void convertCK3ToEU4(const mappers::ConverterVersion& converterVersion)
 {
 	Log(LogLevel::Progress) << "0 %";
-	auto theConfiguration = std::make_shared<Configuration>();
-	const CK3::World sourceWorld(theConfiguration);
+	const auto theConfiguration = std::make_shared<Configuration>(converterVersion);
+	const CK3::World sourceWorld(theConfiguration, converterVersion);
 	EU4::World destWorld(sourceWorld, *theConfiguration, converterVersion);
 	LOG(LogLevel::Info) << "* Conversion complete *";
 	Log(LogLevel::Progress) << "100 %";

--- a/CK3toEU4/Source/CK3World/Geography/CountyDetail.cpp
+++ b/CK3toEU4/Source/CK3World/Geography/CountyDetail.cpp
@@ -17,9 +17,13 @@ void CK3::CountyDetail::registerKeys()
 	});
 	registerKeyword("culture", [this](const std::string& unused, std::istream& theStream) {
 		culture = std::make_pair(commonItems::singleLlong(theStream).getLlong(), nullptr);
+		if (culture.first == 4294967295)
+			culture.first = 0;
 	});
 	registerKeyword("faith", [this](const std::string& unused, std::istream& theStream) {
 		faith = std::make_pair(commonItems::singleLlong(theStream).getLlong(), nullptr);
+		if (faith.first == 4294967295)
+			faith.first = 0;
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }

--- a/CK3toEU4/Source/CK3World/World.h
+++ b/CK3toEU4/Source/CK3World/World.h
@@ -1,6 +1,6 @@
 #ifndef CK3_WORLD_H
 #define CK3_WORLD_H
-
+#include "../Mappers/ConverterVersion/ConverterVersion.h"
 #include "../Mappers/IAmHreMapper/IAmHreMapper.h"
 #include "../Mappers/NamedColors/NamedColors.h"
 #include "../Mappers/ShatterEmpiresMapper/ShatterEmpiresMapper.h"
@@ -29,7 +29,7 @@ namespace CK3
 class World: commonItems::parser
 {
   public:
-	explicit World(const std::shared_ptr<Configuration>& theConfiguration);
+	explicit World(const std::shared_ptr<Configuration>& theConfiguration, const mappers::ConverterVersion& converterVersion);
 
 	[[nodiscard]] const auto& getConversionDate() const { return endDate; }
 	[[nodiscard]] const auto& getIndeps() const { return independentTitles; }

--- a/CK3toEU4/Source/Configuration/Configuration.h
+++ b/CK3toEU4/Source/Configuration/Configuration.h
@@ -1,14 +1,14 @@
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
-
-#include "Date.h"
+#include "../Mappers/ConverterVersion/ConverterVersion.h"
 #include "Parser.h"
 #include <set>
 
 class Configuration: commonItems::parser
 {
   public:
-	Configuration();
+	Configuration() = default;
+	explicit Configuration(const mappers::ConverterVersion& converterVersion);
 	explicit Configuration(std::istream& theStream);
 
 	enum class STARTDATE
@@ -98,6 +98,9 @@ class Configuration: commonItems::parser
 	void setOutputName();
 	void verifyCK3Path();
 	void verifyEU4Path() const;
+	void verifyCK3Version(const mappers::ConverterVersion& converterVersion) const;
+	void verifyEU4Version(const mappers::ConverterVersion& converterVersion) const;
+	[[nodiscard]] std::optional<GameVersion> getRawVersion(const std::string& filePath) const;
 
 	std::string SaveGamePath;
 	std::string CK3Path;

--- a/CK3toEU4/Source/Configuration/Configuration.h
+++ b/CK3toEU4/Source/Configuration/Configuration.h
@@ -98,9 +98,9 @@ class Configuration: commonItems::parser
 	void setOutputName();
 	void verifyCK3Path();
 	void verifyEU4Path() const;
+	[[nodiscard]] std::optional<GameVersion> getRawVersion(const std::string& filePath) const;
 	void verifyCK3Version(const mappers::ConverterVersion& converterVersion) const;
 	void verifyEU4Version(const mappers::ConverterVersion& converterVersion) const;
-	[[nodiscard]] std::optional<GameVersion> getRawVersion(const std::string& filePath) const;
 
 	std::string SaveGamePath;
 	std::string CK3Path;

--- a/CK3toEU4/Source/EU4World/EU4World.cpp
+++ b/CK3toEU4/Source/EU4World/EU4World.cpp
@@ -464,7 +464,7 @@ void EU4::World::importCK3Provinces(const CK3::World& sourceWorld)
 		if (ck3Titles.empty())
 			continue;
 		// Next, we find what province to use as its initializing source.
-		const auto& sourceProvince = determineProvinceSource(ck3Titles, sourceWorld);
+		const auto& sourceProvince = determineProvinceSource(ck3Titles);
 		if (!sourceProvince)
 		{
 			Log(LogLevel::Warning) << "Mismap on CK3 province import for EU4 province: " << province.first;
@@ -481,8 +481,7 @@ void EU4::World::importCK3Provinces(const CK3::World& sourceWorld)
 }
 
 std::optional<std::pair<std::string, std::shared_ptr<CK3::Title>>> EU4::World::determineProvinceSource(
-	 const std::map<std::string, std::shared_ptr<CK3::Title>>& ck3Titles,
-	 const CK3::World& sourceWorld) const
+	 const std::map<std::string, std::shared_ptr<CK3::Title>>& ck3Titles) const
 {
 	// determine ownership by province development.
 	std::map<long long, std::map<std::string, std::shared_ptr<CK3::Title>>> theClaims; // holderID, offered province sources
@@ -496,9 +495,15 @@ std::optional<std::pair<std::string, std::shared_ptr<CK3::Title>>> EU4::World::d
 	for (auto ck3Title: ck3Titles)
 	{
 		if (!ck3Title.second->getHoldingTitle().second)
-			throw std::runtime_error(ck3Title.first + " has no holding title?");
+		{
+			Log(LogLevel::Error) << ck3Title.first << " has no holding title? Did you import this save from an old version?";
+			continue;	
+		}		
 		if (!ck3Title.second->getHoldingTitle().second->getHolder())
-			throw std::runtime_error(ck3Title.first + " has no holding title holder?");
+		{
+			Log(LogLevel::Error) << ck3Title.first + " has no holding title holder? Did you import this save from an old version?";
+			continue;
+		}
 		const auto holderID = ck3Title.second->getHoldingTitle().second->getHolder()->first; // this is the fellow owning this land.
 		theClaims[holderID].insert(ck3Title);
 		theShares[holderID] += ck3Title.second->getBuildingWeight(devWeightsMapper);

--- a/CK3toEU4/Source/EU4World/EU4World.h
+++ b/CK3toEU4/Source/EU4World/EU4World.h
@@ -45,8 +45,7 @@ class World
 	void importVanillaProvinces(const std::string& eu4Path, bool invasion);
 	void importCK3Provinces(const CK3::World& sourceWorld);
 	[[nodiscard]] std::optional<std::pair<std::string, std::shared_ptr<CK3::Title>>> determineProvinceSource(
-		 const std::map<std::string, std::shared_ptr<CK3::Title>>& ck3Titles,
-		 const CK3::World& sourceWorld) const;
+		 const std::map<std::string, std::shared_ptr<CK3::Title>>& ck3Titles) const;
 
 	// processing
 	void alterProvinceDevelopment();

--- a/CK3toEU4/Source/EU4World/Output/outConverterVersion.cpp
+++ b/CK3toEU4/Source/EU4World/Output/outConverterVersion.cpp
@@ -5,7 +5,7 @@ std::ostream& mappers::operator<<(std::ostream& output, const ConverterVersion& 
 	output << "\n\n";
 	output << "************ -= The Paradox Converters Team =- ********************\n";
 	output << "* Converter version " << version.version << " \"" << version.name << "\"\n";
-	output << "* " << version.descriptionLine << "\n";
+	output << "* " << version.getDescription() << "\n";
 	output << "* Built on " << __TIMESTAMP__ << "\n";
 	output << "********************** + CK3 To EU4 + *****************************\n";
 	return output;

--- a/CK3toEU4/Source/Mappers/ConverterVersion/ConverterVersion.cpp
+++ b/CK3toEU4/Source/Mappers/ConverterVersion/ConverterVersion.cpp
@@ -1,6 +1,6 @@
 #include "ConverterVersion.h"
-#include "ParserHelpers.h"
 #include "CommonRegexes.h"
+#include "ParserHelpers.h"
 
 mappers::ConverterVersion::ConverterVersion()
 {
@@ -23,20 +23,16 @@ void mappers::ConverterVersion::registerKeys()
 	registerSetter("source", source);
 	registerSetter("target", target);
 	registerKeyword("minSource", [this](std::istream& theStream) {
-		const auto tempString = commonItems::getString(theStream);
-		minSource = GameVersion(tempString);
+		minSource = GameVersion(commonItems::getString(theStream));
 	});
 	registerKeyword("maxSource", [this](std::istream& theStream) {
-		const auto tempString = commonItems::getString(theStream);
-		maxSource = GameVersion(tempString);
+		maxSource = GameVersion(commonItems::getString(theStream));
 	});
 	registerKeyword("minTarget", [this](std::istream& theStream) {
-		const auto tempString = commonItems::getString(theStream);
-		minTarget = GameVersion(tempString);
+		minTarget = GameVersion(commonItems::getString(theStream));
 	});
 	registerKeyword("maxTarget", [this](std::istream& theStream) {
-		const auto tempString = commonItems::getString(theStream);
-		maxTarget = GameVersion(tempString);
+		maxTarget = GameVersion(commonItems::getString(theStream));
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }

--- a/CK3toEU4/Source/Mappers/ConverterVersion/ConverterVersion.cpp
+++ b/CK3toEU4/Source/Mappers/ConverterVersion/ConverterVersion.cpp
@@ -18,17 +18,38 @@ mappers::ConverterVersion::ConverterVersion(std::istream& theStream)
 
 void mappers::ConverterVersion::registerKeys()
 {
-	registerKeyword("name", [this](const std::string& unused, std::istream& theStream) {
-		const commonItems::singleString nameStr(theStream);
-		name = nameStr.getString();
+	registerSetter("name", name);
+	registerSetter("version", version);
+	registerSetter("source", source);
+	registerSetter("target", target);
+	registerKeyword("minSource", [this](std::istream& theStream) {
+		const auto tempString = commonItems::getString(theStream);
+		minSource = GameVersion(tempString);
 	});
-	registerKeyword("version", [this](const std::string& unused, std::istream& theStream) {
-		const commonItems::singleString versionStr(theStream);
-		version = versionStr.getString();
+	registerKeyword("maxSource", [this](std::istream& theStream) {
+		const auto tempString = commonItems::getString(theStream);
+		maxSource = GameVersion(tempString);
 	});
-	registerKeyword("descriptionLine", [this](const std::string& unused, std::istream& theStream) {
-		const commonItems::singleString descriptionLineStr(theStream);
-		descriptionLine = descriptionLineStr.getString();
+	registerKeyword("minTarget", [this](std::istream& theStream) {
+		const auto tempString = commonItems::getString(theStream);
+		minTarget = GameVersion(tempString);
+	});
+	registerKeyword("maxTarget", [this](std::istream& theStream) {
+		const auto tempString = commonItems::getString(theStream);
+		maxTarget = GameVersion(tempString);
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
+}
+
+std::string mappers::ConverterVersion::getDescription() const
+{
+	auto toReturn = "Compatible with " + source + " [v" + minSource.toShortString();
+	if (maxSource != minSource)
+		toReturn += "-v" + maxSource.toShortString();
+	toReturn += "] and " + target + " [v" + minTarget.toShortString();
+	if (maxTarget != minTarget)
+		toReturn += "-v" + maxTarget.toShortString();
+	toReturn += "]";
+
+	return toReturn;
 }

--- a/CK3toEU4/Source/Mappers/ConverterVersion/ConverterVersion.h
+++ b/CK3toEU4/Source/Mappers/ConverterVersion/ConverterVersion.h
@@ -1,12 +1,12 @@
 #ifndef CONVERTER_VERSION_H
 #define CONVERTER_VERSION_H
-
+#include "GameVersion.h"
 #include "Parser.h"
 
 namespace mappers
 {
 
-class ConverterVersion: commonItems::parser
+class ConverterVersion: commonItems::convenientParser
 {
   public:
 	ConverterVersion();
@@ -15,14 +15,24 @@ class ConverterVersion: commonItems::parser
 	friend std::ostream& operator<<(std::ostream& output, const ConverterVersion& version);
 	[[nodiscard]] const auto& getName() const { return name; }
 	[[nodiscard]] const auto& getVersion() const { return version; }
-	[[nodiscard]] const auto& getDescription() const { return descriptionLine; }
+	[[nodiscard]] std::string getDescription() const;
+
+	[[nodiscard]] const auto& getMinSource() const { return minSource; }
+	[[nodiscard]] const auto& getMaxSource() const { return maxSource; }
+	[[nodiscard]] const auto& getMinTarget() const { return minTarget; }
+	[[nodiscard]] const auto& getMaxTarget() const { return maxTarget; }
 
   private:
 	void registerKeys();
 
 	std::string name;
 	std::string version;
-	std::string descriptionLine;
+	std::string source;
+	std::string target;
+	GameVersion minSource;
+	GameVersion maxSource;
+	GameVersion minTarget;
+	GameVersion maxTarget;
 };
 
 } // namespace mappers

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export CC=/usr/bin/gcc-10 &&
-export CXX=/usr/bin/g++-10 &&
+export CC=/usr/bin/gcc-11 &&
+export CXX=/usr/bin/g++-11 &&
 
 cd imageMagick &&
 cat im7.10.tar.* > im7.10-linux-source.tar &&


### PR DESCRIPTION
This is the proposed rework of ConverterVersion that should be useful for all converters as early detection of version incompatibilities avoids many user errors. Version checking for games should be done by converters themselves as done here, as each setup has its own specifics, so eu4tovic2 likely won't bother with minSource and maxSource.

Please note we already have a ConverterVersion in commons that should/could be replaced by this one here when all converters are swapped.

Also, this PR solves f**n kintus, let them burn.