### PR TITLE
Pass Fix

### DIFF
--- a/CK3toEU4/Source/EU4World/EU4World.cpp
+++ b/CK3toEU4/Source/EU4World/EU4World.cpp
@@ -1672,27 +1672,39 @@ void EU4::World::africanQuestion()
 			continue;
 
 		// check owners of pass ends.
-		std::vector<int> endProvinces = pass.getEndA();
-		endProvinces.insert(endProvinces.end(), pass.getEndB().begin(), pass.getEndB().end());
-		std::map<std::string, std::vector<int>> ownerProvinces;
+		bool hasStart = false;
+		bool hasEnd = false;
 
-		for (const auto& provinceID: endProvinces)
+		for (const auto& provinceID: pass.getEndA())
 		{
 			if (!provinces.find(provinceID)->second->getOwner().empty())
-				ownerProvinces[provinces.find(provinceID)->second->getOwner()].emplace_back(provinceID);
+				hasStart = true;
 		}
-		if (ownerProvinces.size() == 1 && ownerProvinces.begin()->second.size() == endProvinces.size())
+		for (const auto& provinceID: pass.getEndB())
+		{
+			if (!provinces.find(provinceID)->second->getOwner().empty())
+				hasEnd = true;
+		}
+		if (hasStart && hasEnd)
 			continue; // all under same owner.
 
 		// check HRE
-		std::vector<int> hreProvinces;
-		for (const auto& provinceID: endProvinces)
+		hasStart = false;
+		hasEnd = false;
+
+		for (const auto& provinceID: pass.getEndA())
 		{
 			const auto& country = countries.find(provinces.find(provinceID)->second->getOwner());
 			if (country != countries.end() && country->second && country->second->isinHRE())
-				hreProvinces.emplace_back(provinceID);
+				hasStart = true;
 		}
-		if (hreProvinces.size() == endProvinces.size())
+		for (const auto& provinceID: pass.getEndB())
+		{
+			const auto& country = countries.find(provinces.find(provinceID)->second->getOwner());
+			if (country != countries.end() && country->second && country->second->isinHRE())
+				hasEnd = true;
+		}
+		if (hasStart && hasEnd)
 			continue; // all provinces in hre
 
 		// sterilize

--- a/CK3toEU4/Source/EU4World/EU4World.cpp
+++ b/CK3toEU4/Source/EU4World/EU4World.cpp
@@ -1689,8 +1689,11 @@ void EU4::World::africanQuestion()
 		}
 		for (const auto& owner: ownersA)
 		{
-			if (!ownersB.find(owner)->empty())
+			if (!ownersB.contains(owner))
+			{
 				hasStart = true;
+				break;
+			}
 		}
 		if (hasStart)
 			continue; // all under same owner.

--- a/CK3toEU4/Source/EU4World/EU4World.cpp
+++ b/CK3toEU4/Source/EU4World/EU4World.cpp
@@ -1672,25 +1672,31 @@ void EU4::World::africanQuestion()
 			continue;
 
 		// check owners of pass ends.
+		std::set<std::string> ownersA;
+		std::set<std::string> ownersB;
 		bool hasStart = false;
 		bool hasEnd = false;
 
 		for (const auto& provinceID: pass.getEndA())
 		{
 			if (!provinces.find(provinceID)->second->getOwner().empty())
-				hasStart = true;
+				ownersA.insert(provinces.find(provinceID)->second->getOwner());
 		}
 		for (const auto& provinceID: pass.getEndB())
 		{
 			if (!provinces.find(provinceID)->second->getOwner().empty())
-				hasEnd = true;
+				ownersB.insert(provinces.find(provinceID)->second->getOwner());
 		}
-		if (hasStart && hasEnd)
+		for (const auto& owner: ownersA)
+		{
+			if (!ownersB.find(owner)->empty())
+				hasStart = true;
+		}
+		if (hasStart)
 			continue; // all under same owner.
 
 		// check HRE
 		hasStart = false;
-		hasEnd = false;
 
 		for (const auto& provinceID: pass.getEndA())
 		{


### PR DESCRIPTION
- Passes are now filled if a country own ONE of two end provinces rather than needing to own both. 
e.g - Country XYZ owns province A which borders both the pass and province B which also borders the pass but is owned by country UVW. Country XYZ also owns another province on the other end of the pass, province c. Previously, this would leave the pass blank and disconnect country XYZ, it now reads the pass as normal.