### PR TITLE
Custom map names convert

### DIFF
--- a/CK3ToEU4Tests/CK3ToEU4Tests.vcxproj
+++ b/CK3ToEU4Tests/CK3ToEU4Tests.vcxproj
@@ -248,6 +248,7 @@
     <ClCompile Include="MapperTests\PrimaryTagMapper\PrimaryTagCultureGroupTests.cpp" />
     <ClCompile Include="MapperTests\PrimaryTagMapper\PrimaryTagCultureTests.cpp" />
     <ClCompile Include="MapperTests\PrimaryTagMapper\PrimaryTagMapperTests.cpp" />
+    <ClCompile Include="MapperTests\ProvinceMapper\NameTransferMappingTests.cpp" />
     <ClCompile Include="MapperTests\ProvinceMapper\ProvinceMapperTests.cpp" />
     <ClCompile Include="MapperTests\ProvinceMapper\ProvinceMappingsVersionTests.cpp" />
     <ClCompile Include="MapperTests\ProvinceMapper\ProvinceMappingTests.cpp" />

--- a/CK3ToEU4Tests/CK3ToEU4Tests.vcxproj
+++ b/CK3ToEU4Tests/CK3ToEU4Tests.vcxproj
@@ -131,6 +131,9 @@
     <ClCompile Include="..\CK3toEU4\Source\EU4World\Output\outProvince.cpp" />
     <ClCompile Include="..\CK3toEU4\Source\EU4World\Output\outReligion.cpp" />
     <ClCompile Include="..\CK3toEU4\Source\EU4World\Output\outWorld.cpp" />
+    <ClCompile Include="..\CK3toEU4\Source\EU4World\Province\EU4Province.cpp" />
+    <ClCompile Include="..\CK3toEU4\Source\EU4World\Province\ProvinceDetails.cpp" />
+    <ClCompile Include="..\CK3toEU4\Source\EU4World\Province\ProvinceModifier.cpp" />
     <ClCompile Include="..\CK3toEU4\Source\EU4World\Religion\GeneratedReligion.cpp" />
     <ClCompile Include="..\CK3toEU4\Source\Mappers\AfricanPassesMapper\AfricanPassesMapper.cpp" />
     <ClCompile Include="..\CK3toEU4\Source\Mappers\AfricanPassesMapper\AfricanPassesMapping.cpp" />

--- a/CK3ToEU4Tests/CK3ToEU4Tests.vcxproj.filters
+++ b/CK3ToEU4Tests/CK3ToEU4Tests.vcxproj.filters
@@ -253,6 +253,9 @@
     <Filter Include="EU4WorldTests\IdeaTests">
       <UniqueIdentifier>{9027090e-4c4c-4594-8a9d-415d5c51072f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="CK3ToEU4\EU4World\Province">
+      <UniqueIdentifier>{e56b76f3-f744-495c-a67c-ec9693f4d76a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\googletest\googletest\src\gtest_main.cc" />
@@ -790,6 +793,15 @@
     </ClCompile>
     <ClCompile Include="MapperTests\ProvinceMapper\NameTransferMappingTests.cpp">
       <Filter>MapperTests\ProvinceMapperTests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CK3toEU4\Source\EU4World\Province\EU4Province.cpp">
+      <Filter>CK3ToEU4\EU4World\Province</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CK3toEU4\Source\EU4World\Province\ProvinceDetails.cpp">
+      <Filter>CK3ToEU4\EU4World\Province</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CK3toEU4\Source\EU4World\Province\ProvinceModifier.cpp">
+      <Filter>CK3ToEU4\EU4World\Province</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/CK3ToEU4Tests/CK3ToEU4Tests.vcxproj.filters
+++ b/CK3ToEU4Tests/CK3ToEU4Tests.vcxproj.filters
@@ -788,6 +788,9 @@
     <ClCompile Include="MapperTests\DynamicIdeasMapperTests\DynamicIdeasRuleTests.cpp">
       <Filter>MapperTests\DynamicIdeasMapperTests</Filter>
     </ClCompile>
+    <ClCompile Include="MapperTests\ProvinceMapper\NameTransferMappingTests.cpp">
+      <Filter>MapperTests\ProvinceMapperTests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="..\imageMagick\dll-windows-required\CORE_RL_bzlib_.dll">

--- a/CK3ToEU4Tests/MapperTests/ProvinceMapper/NameTransferMappingTests.cpp
+++ b/CK3ToEU4Tests/MapperTests/ProvinceMapper/NameTransferMappingTests.cpp
@@ -1,10 +1,59 @@
+#include "../CK3toEU4/Source/CK3World/Geography/CountyDetails.h"
 #include "../CK3toEU4/Source/CK3World/Titles/LandedTitles.h"
 #include "../CK3toEU4/Source/CK3World/Titles/Title.h"
 #include "../CK3toEU4/Source/CK3World/Titles/Titles.h"
+#include "../CK3toEU4/Source/EU4World/Province/EU4Province.h"
+#include "../CK3toEU4/Source/Mappers/CultureMapper/CultureMapper.h"
+#include "../CK3toEU4/Source/Mappers/LocDegraderMapper/LocDegraderMapper.h"
 #include "../CK3toEU4/Source/Mappers/ProvinceMapper/ProvinceMapper.h"
+#include "../CK3toEU4/Source/Mappers/ReligionMapper/ReligionMapper.h"
 #include "gtest/gtest.h"
 #include <sstream>
 
+TEST(Mappers_NameTransferTests, oneToOneTransfersName)
+{
+	std::stringstream provinceMapperStream;
+	provinceMapperStream << "0.0.0.0 = {\n";
+	provinceMapperStream << " link = { eu4 = 1 ck3 = 1 }\n";
+	provinceMapperStream << "}";
+	mappers::ProvinceMapper provinceMapper(provinceMapperStream);
+
+	std::stringstream landedTitlesStream;
+	landedTitlesStream << "b_barony1 = { province = 1 }\n";
+	landedTitlesStream << "c_county1 = { }\n";
+	CK3::LandedTitles landedTitles;
+	landedTitles.loadTitles(landedTitlesStream);
+	// landedTitles.linkCountyDetails(countyDetails); May need Development values in order to work.
+
+	std::stringstream titlesStream;
+	titlesStream << "1={key=b_barony1 name=Barony1 de_jure_liege=2}\n";
+	titlesStream << "2={key=c_county1 name=County1 renamed=yes}\n";
+	CK3::Titles titles(titlesStream);
+	titles.linkTitles();
+	titles.linkLandedTitles(landedTitles);
+
+	provinceMapper.transliterateMappings(titles.getTitles());
+
+	// Bypassing determineProvinceSource, which does not have a test
+	const auto& srcProvince = titles.getTitles().at("c_county1");
+	srcProvince->pickDisplayName(titles.getTitles());
+
+	// initialize an EU4 province with initializeFromCK3Title
+	EU4::Province outProvince = EU4::Province();
+	std::stringstream dummy;
+	dummy << "link = { eu4 = culture ck3 = culture }";
+	const mappers::CultureMapper culMap(dummy);
+	const mappers::ReligionMapper religMap(dummy);
+	const mappers::LocDegraderMapper locDegrader(dummy);
+
+	// Fatal error LNK2019: unresolved external symbol 
+	outProvince.initializeFromCK3Title(srcProvince, culMap, religMap, locDegrader); // gives error LNK2019
+	outProvince.setAdm(5); // works
+	outProvince.cul(culMap); // gives error LNK2019
+
+	EXPECT_EQ(outProvince.isRenamed(), true);				// EU4 srcProvince should have the renamed flag
+	EXPECT_EQ(outProvince.getCustomName(), "County1"); // EU4 province should have the new manual displayName
+}
 // Things to test
 // 1:1
 // N:1

--- a/CK3ToEU4Tests/MapperTests/ProvinceMapper/NameTransferMappingTests.cpp
+++ b/CK3ToEU4Tests/MapperTests/ProvinceMapper/NameTransferMappingTests.cpp
@@ -1,0 +1,16 @@
+#include "../CK3toEU4/Source/CK3World/Titles/LandedTitles.h"
+#include "../CK3toEU4/Source/CK3World/Titles/Title.h"
+#include "../CK3toEU4/Source/CK3World/Titles/Titles.h"
+#include "../CK3toEU4/Source/Mappers/ProvinceMapper/ProvinceMapper.h"
+#include "gtest/gtest.h"
+#include <sstream>
+
+// Things to test
+// 1:1
+// N:1
+// 1:M
+// N:M
+// non-latin base not carried forward
+// duchy capital priority observed
+// duchy capital priority not observed when duchy owner split
+// duchy capital priority not observed when in separate mapping

--- a/CK3ToEU4Tests/MapperTests/ProvinceMapper/NameTransferMappingTests.cpp
+++ b/CK3ToEU4Tests/MapperTests/ProvinceMapper/NameTransferMappingTests.cpp
@@ -136,7 +136,7 @@ TEST(Mappers_NameTransferTests, oneToManyTransfersName)
 
 	EXPECT_EQ(outProvince.isRenamed(), true);				// EU4 province should have the renamed flag
 	EXPECT_EQ(outProvince.getCustomName(), "County1"); // EU4 province should have the new manual displayName
-	EXPECT_EQ(outProvince2.isRenamed(), false); //second EU4 province should NOT have the renamed flag
+	EXPECT_EQ(outProvince2.isRenamed(), false);			// second EU4 province should NOT have the renamed flag
 }
 TEST(Mappers_NameTransferTests, nondegradeableNamesDefualtsToVanilla)
 {

--- a/CK3ToEU4Tests/MapperTests/ProvinceMapper/NameTransferMappingTests.cpp
+++ b/CK3ToEU4Tests/MapperTests/ProvinceMapper/NameTransferMappingTests.cpp
@@ -87,8 +87,8 @@ TEST(Mappers_NameTransferTests, manyToOneTransfersName)
 
 	// DF lieges are squashed by not having a valid holder, bypass that
 	const auto& duchy = titles.getTitles().at("d_duchy1");
-	titles.getTitles().at("c_county1")->loadDFLiege(std::make_pair(duchy->getID(),duchy));
-	titles.getTitles().at("c_county2")->loadDFLiege(std::make_pair(duchy->getID(),duchy));
+	titles.getTitles().at("c_county1")->loadDFLiege(std::make_pair(duchy->getID(), duchy));
+	titles.getTitles().at("c_county2")->loadDFLiege(std::make_pair(duchy->getID(), duchy));
 
 	// Bypassing determineProvinceSource, which does not have a test
 	const auto& srcProvince = titles.getTitles().at("c_county2");

--- a/CK3toEU4/Data_Files/configurables/tradition_ideas.txt
+++ b/CK3toEU4/Data_Files/configurables/tradition_ideas.txt
@@ -104,7 +104,7 @@ link = { ck3 = { tradition = tradition_gardening } eu4 = { global_prosperity_gro
 link = { ck3 = { tradition = tradition_garuda_warriors } eu4 = { special_unit_forcelimit = 0.05 recover_army_morale_speed = 0.10 } } 
 link = { ck3 = { tradition = tradition_hard_working } eu4 = { build_cost = -0.1 } } 
 link = { ck3 = { tradition = tradition_hereditary_hierarchy } eu4 = { free_adm_policy = 1 } }
-link = { ck3 = { tradition = tradition_hiden_cities } eu4 = { war_exhaustion = -0.10 } } 
+link = { ck3 = { tradition = tradition_hidden_cities } eu4 = { war_exhaustion = -0.10 } } 
 link = { ck3 = { tradition = tradition_highland_warriors } eu4 = { global_supply_limit_modifier = 0.10 } } 
 link = { ck3 = { tradition = tradition_hill_dwellers } eu4 = { development_cost = -0.1 } } 
 link = { ck3 = { tradition = tradition_himalayan_settlers } eu4 = { special_unit_forcelimit = 0.05 global_supply_limit_modifier = 0.10 } }
@@ -121,6 +121,7 @@ link = { ck3 = { tradition = tradition_jungle_warriors } eu4 = { global_supply_l
 link = { ck3 = { tradition = tradition_khadga_puja } eu4 = { special_unit_forcelimit = 0.05 infantry_shock = 1} } 
 link = { ck3 = { tradition = tradition_land_of_the_bow } eu4 = { special_unit_forcelimit = 0.05 infantry_fire = 1 } } 
 link = { ck3 = { tradition = tradition_language_scholars } eu4 = { monarch_diplomatic_power = 1 } } 
+link = { ck3 = { tradition = tradition_legalistic } eu4 = { governing_capacity_modifier = 0.1 } } 
 link = { ck3 = { tradition = tradition_life_is_just_a_joke } eu4 = { global_unrest = -2 } } 
 link = { ck3 = { tradition = tradition_longbow_competitions } eu4 = { special_unit_forcelimit = 0.05 infantry_fire = 1 } } 
 link = { ck3 = { tradition = tradition_lords_of_the_elephant } eu4 = { cavalry_power = 0.15 } } 
@@ -130,7 +131,7 @@ link = { ck3 = { tradition = tradition_maritime_mercantilism } eu4 = { mercantil
 link = { ck3 = { tradition = tradition_martial_admiration } eu4 = { army_tradition = 1 } } 
 link = { ck3 = { tradition = tradition_medicinal_plants } eu4 = { global_spy_defence = 0.1  } }
 link = { ck3 = { tradition = tradition_mendicant_mystics } eu4 = { merchant = 1 } } 
-link = { ck3 = { tradition = tradition_merciful_blinding } eu4 = { harsh_treatment_cost = -0.2 } } 
+link = { ck3 = { tradition = tradition_merciful_blindings } eu4 = { harsh_treatment_cost = -0.2 } } 
 link = { ck3 = { tradition = tradition_metal_craftsmanship } eu4 = { reinforce_cost_modifier = -0.10 } }
 link = { ck3 = { tradition = tradition_mobile_guards } eu4 = { special_unit_forcelimit = 0.05 shock_damage_received = -0.10 } } 
 link = { ck3 = { tradition = tradition_modest } eu4 = { administrative_efficiency = 0.1 } } 
@@ -154,7 +155,7 @@ link = { ck3 = { tradition = tradition_polders} eu4 = { development_cost = -0.1 
 link = { ck3 = { tradition = tradition_polygamous } eu4 = { diplomatic_reputation = 1 } }
 link = { ck3 = { tradition = tradition_praticed_pirates } eu4 = { may_perform_slave_raid = yes} }
 link = { ck3 = { tradition = tradition_quarrelsome } eu4 = { unjustified_demands = -0.2 }  } 
-link = { ck3 = { tradition = tradition_republican_legacy } eu4 = { burghers_loyalty_modifier = 0.1 republican_tradition 0.5 } } 
+link = { ck3 = { tradition = tradition_republican_legacy } eu4 = { burghers_loyalty_modifier = 0.1 republican_tradition = 0.5 } } 
 link = { ck3 = { tradition = tradition_religion_blending } eu4 = { tolerance_heathen = 1 tolerance_heretic = 1 } } 
 link = { ck3 = { tradition = tradition_religious_patronage } eu4 = { institution_spread_from_true_faith = 0.15 } } 
 link = { ck3 = { tradition = tradition_reverence_for_veterans } eu4 = { innovativeness_gain = 0.5 army_tradition_decay = -0.01 } } 

--- a/CK3toEU4/Data_Files/configurables/tradition_ideas.txt
+++ b/CK3toEU4/Data_Files/configurables/tradition_ideas.txt
@@ -104,7 +104,7 @@ link = { ck3 = { tradition = tradition_gardening } eu4 = { global_prosperity_gro
 link = { ck3 = { tradition = tradition_garuda_warriors } eu4 = { special_unit_forcelimit = 0.05 recover_army_morale_speed = 0.10 } } 
 link = { ck3 = { tradition = tradition_hard_working } eu4 = { build_cost = -0.1 } } 
 link = { ck3 = { tradition = tradition_hereditary_hierarchy } eu4 = { free_adm_policy = 1 } }
-link = { ck3 = { tradition = tradition_hidden_cities } eu4 = { war_exhaustion = -0.10 } } 
+link = { ck3 = { tradition = tradition_hiden_cities } eu4 = { war_exhaustion = -0.10 } } 
 link = { ck3 = { tradition = tradition_highland_warriors } eu4 = { global_supply_limit_modifier = 0.10 } } 
 link = { ck3 = { tradition = tradition_hill_dwellers } eu4 = { development_cost = -0.1 } } 
 link = { ck3 = { tradition = tradition_himalayan_settlers } eu4 = { special_unit_forcelimit = 0.05 global_supply_limit_modifier = 0.10 } }
@@ -121,7 +121,6 @@ link = { ck3 = { tradition = tradition_jungle_warriors } eu4 = { global_supply_l
 link = { ck3 = { tradition = tradition_khadga_puja } eu4 = { special_unit_forcelimit = 0.05 infantry_shock = 1} } 
 link = { ck3 = { tradition = tradition_land_of_the_bow } eu4 = { special_unit_forcelimit = 0.05 infantry_fire = 1 } } 
 link = { ck3 = { tradition = tradition_language_scholars } eu4 = { monarch_diplomatic_power = 1 } } 
-link = { ck3 = { tradition = tradition_legalistic } eu4 = { governing_capacity_modifier = 0.1 } } 
 link = { ck3 = { tradition = tradition_life_is_just_a_joke } eu4 = { global_unrest = -2 } } 
 link = { ck3 = { tradition = tradition_longbow_competitions } eu4 = { special_unit_forcelimit = 0.05 infantry_fire = 1 } } 
 link = { ck3 = { tradition = tradition_lords_of_the_elephant } eu4 = { cavalry_power = 0.15 } } 
@@ -131,7 +130,7 @@ link = { ck3 = { tradition = tradition_maritime_mercantilism } eu4 = { mercantil
 link = { ck3 = { tradition = tradition_martial_admiration } eu4 = { army_tradition = 1 } } 
 link = { ck3 = { tradition = tradition_medicinal_plants } eu4 = { global_spy_defence = 0.1  } }
 link = { ck3 = { tradition = tradition_mendicant_mystics } eu4 = { merchant = 1 } } 
-link = { ck3 = { tradition = tradition_merciful_blindings } eu4 = { harsh_treatment_cost = -0.2 } } 
+link = { ck3 = { tradition = tradition_merciful_blinding } eu4 = { harsh_treatment_cost = -0.2 } } 
 link = { ck3 = { tradition = tradition_metal_craftsmanship } eu4 = { reinforce_cost_modifier = -0.10 } }
 link = { ck3 = { tradition = tradition_mobile_guards } eu4 = { special_unit_forcelimit = 0.05 shock_damage_received = -0.10 } } 
 link = { ck3 = { tradition = tradition_modest } eu4 = { administrative_efficiency = 0.1 } } 
@@ -155,7 +154,7 @@ link = { ck3 = { tradition = tradition_polders} eu4 = { development_cost = -0.1 
 link = { ck3 = { tradition = tradition_polygamous } eu4 = { diplomatic_reputation = 1 } }
 link = { ck3 = { tradition = tradition_praticed_pirates } eu4 = { may_perform_slave_raid = yes} }
 link = { ck3 = { tradition = tradition_quarrelsome } eu4 = { unjustified_demands = -0.2 }  } 
-link = { ck3 = { tradition = tradition_republican_legacy } eu4 = { burghers_loyalty_modifier = 0.1 republican_tradition = 0.5 } } 
+link = { ck3 = { tradition = tradition_republican_legacy } eu4 = { burghers_loyalty_modifier = 0.1 republican_tradition 0.5 } } 
 link = { ck3 = { tradition = tradition_religion_blending } eu4 = { tolerance_heathen = 1 tolerance_heretic = 1 } } 
 link = { ck3 = { tradition = tradition_religious_patronage } eu4 = { institution_spread_from_true_faith = 0.15 } } 
 link = { ck3 = { tradition = tradition_reverence_for_veterans } eu4 = { innovativeness_gain = 0.5 army_tradition_decay = -0.01 } } 

--- a/CK3toEU4/Source/CK3World/Titles/Title.cpp
+++ b/CK3toEU4/Source/CK3World/Titles/Title.cpp
@@ -81,8 +81,7 @@ void CK3::Title::registerKeys()
 		holder = std::pair(commonItems::singleLlong(theStream).getLlong(), nullptr);
 	});
 	registerKeyword("renamed", [this](std::istream& theStream) {
-		const auto& isRenamed = commonItems::getString(theStream);
-		renamed = isRenamed == "yes";
+		renamed = commonItems::getString(theStream) == "yes";
 	});
 	registerKeyword("coat_of_arms_id", [this](const std::string& unused, std::istream& theStream) {
 		coa = std::pair(commonItems::singleLlong(theStream).getLlong(), nullptr);
@@ -276,6 +275,25 @@ std::map<std::string, std::shared_ptr<CK3::Title>> CK3::Title::coalesceDJCountie
 	}
 	toReturn.insert(ownedDJCounties.begin(), ownedDJCounties.end());
 	return toReturn;
+}
+
+void CK3::Title::pickDisplayName(const std::map<std::string, std::shared_ptr<Title>>& mappings)
+{
+	// Guard clause all used pointers
+	if (!isRenamed() || !getDJLiege() || !getDJLiege()->second || !getDJLiege()->second->getCapital().second)
+		return;
+
+	const auto& myDuchyCapital = getDJLiege()->second->getCapital().second;
+	if (!myDuchyCapital->getDFLiege() || !getDFLiege())
+		return;
+
+	// If the title's name is transfering to EU4, make sure it makes sense. Thrace should use Constantinople's name...
+	// ... if they belong to the same owner, Constantinople also has a custom name and they are in the same mapping
+	if (myDuchyCapital->isRenamed() && mappings.contains(myDuchyCapital->getName()) &&
+		myDuchyCapital->getDFLiege()->first == getDFLiege()->first)
+	{
+		displayName = myDuchyCapital->getDisplayName();
+	}
 }
 
 void CK3::Title::congregateDFCounties()

--- a/CK3toEU4/Source/CK3World/Titles/Title.cpp
+++ b/CK3toEU4/Source/CK3World/Titles/Title.cpp
@@ -280,11 +280,13 @@ std::map<std::string, std::shared_ptr<CK3::Title>> CK3::Title::coalesceDJCountie
 void CK3::Title::pickDisplayName(const std::map<std::string, std::shared_ptr<Title>>& mappings)
 {
 	// Guard clause all used pointers
-	if (!isRenamed() || !getDJLiege() || !getDJLiege()->second || !getDJLiege()->second->getCapital().second)
+	if (!isRenamed())
 		return;
 
-	const auto& myDuchyCapital = getDJLiege()->second->getCapital().second;
-	if (!myDuchyCapital->getDFLiege() || !getDFLiege())
+	// Duchy capital ptrs are all null_ptr, outsource fixing and validation
+	const auto myDuchyCapital = findDuchyCapital();
+
+	if (!myDuchyCapital || myDuchyCapital->getID() == getID() || !myDuchyCapital->getDFLiege() || !getDFLiege())
 		return;
 
 	// If the title's name is transfering to EU4, make sure it makes sense. Thrace should use Constantinople's name...
@@ -294,6 +296,20 @@ void CK3::Title::pickDisplayName(const std::map<std::string, std::shared_ptr<Tit
 	{
 		displayName = myDuchyCapital->getDisplayName();
 	}
+}
+
+std::shared_ptr<CK3::Title> CK3::Title::findDuchyCapital()
+{
+	if (name[0] != 'c' || !getDJLiege() || !getDJLiege()->second)
+		return nullptr;
+	
+	const auto myDuchy = getDJLiege()->second;
+	const auto& capID = myDuchy->getCapital().first;
+
+	if (myDuchy->getDJVassals().empty() || !myDuchy->getDJVassals().contains(capID) || !myDuchy->getDJVassals().at(capID))
+		return nullptr;
+
+	return myDuchy->getDJVassals().at(capID);
 }
 
 void CK3::Title::congregateDFCounties()

--- a/CK3toEU4/Source/CK3World/Titles/Title.cpp
+++ b/CK3toEU4/Source/CK3World/Titles/Title.cpp
@@ -291,8 +291,7 @@ void CK3::Title::pickDisplayName(const std::map<std::string, std::shared_ptr<Tit
 
 	// If the title's name is transfering to EU4, make sure it makes sense. Thrace should use Constantinople's name...
 	// ... if they belong to the same owner, Constantinople also has a custom name and they are in the same mapping
-	if (myDuchyCapital->isRenamed() && mappings.contains(myDuchyCapital->getName()) &&
-		myDuchyCapital->getDFLiege()->first == getDFLiege()->first)
+	if (myDuchyCapital->isRenamed() && mappings.contains(myDuchyCapital->getName()) && myDuchyCapital->getDFLiege()->first == getDFLiege()->first)
 	{
 		displayName = myDuchyCapital->getDisplayName();
 	}
@@ -302,7 +301,7 @@ std::shared_ptr<CK3::Title> CK3::Title::findDuchyCapital()
 {
 	if (name[0] != 'c' || !getDJLiege() || !getDJLiege()->second)
 		return nullptr;
-	
+
 	const auto myDuchy = getDJLiege()->second;
 	const auto& capID = myDuchy->getCapital().first;
 

--- a/CK3toEU4/Source/CK3World/Titles/Title.cpp
+++ b/CK3toEU4/Source/CK3World/Titles/Title.cpp
@@ -277,7 +277,7 @@ std::map<std::string, std::shared_ptr<CK3::Title>> CK3::Title::coalesceDJCountie
 	return toReturn;
 }
 
-void CK3::Title::pickDisplayName(const std::map<std::string, std::shared_ptr<Title>>& mappings)
+void CK3::Title::pickDisplayName(const std::map<std::string, std::shared_ptr<Title>>& possibleTitles)
 {
 	// Guard clause all used pointers
 	if (!isRenamed())
@@ -291,7 +291,7 @@ void CK3::Title::pickDisplayName(const std::map<std::string, std::shared_ptr<Tit
 
 	// If the title's name is transfering to EU4, make sure it makes sense. Thrace should use Constantinople's name...
 	// ... if they belong to the same owner, Constantinople also has a custom name and they are in the same mapping
-	if (myDuchyCapital->isRenamed() && mappings.contains(myDuchyCapital->getName()) && myDuchyCapital->getDFLiege()->first == getDFLiege()->first)
+	if (myDuchyCapital->isRenamed() && possibleTitles.contains(myDuchyCapital->getName()) && myDuchyCapital->getDFLiege()->first == getDFLiege()->first)
 	{
 		displayName = myDuchyCapital->getDisplayName();
 	}

--- a/CK3toEU4/Source/CK3World/Titles/Title.cpp
+++ b/CK3toEU4/Source/CK3World/Titles/Title.cpp
@@ -80,6 +80,10 @@ void CK3::Title::registerKeys()
 	registerKeyword("holder", [this](const std::string& unused, std::istream& theStream) {
 		holder = std::pair(commonItems::singleLlong(theStream).getLlong(), nullptr);
 	});
+	registerKeyword("renamed", [this](std::istream& theStream) {
+		const auto& isRenamed = commonItems::getString(theStream);
+		renamed = isRenamed == "yes";
+	});
 	registerKeyword("coat_of_arms_id", [this](const std::string& unused, std::istream& theStream) {
 		coa = std::pair(commonItems::singleLlong(theStream).getLlong(), nullptr);
 	});

--- a/CK3toEU4/Source/CK3World/Titles/Title.cpp
+++ b/CK3toEU4/Source/CK3World/Titles/Title.cpp
@@ -286,7 +286,7 @@ void CK3::Title::pickDisplayName(const std::map<std::string, std::shared_ptr<Tit
 	// Duchy capital ptrs are all null_ptr, outsource fixing and validation
 	const auto myDuchyCapital = findDuchyCapital();
 
-	if (!myDuchyCapital || myDuchyCapital->getID() == getID() || !myDuchyCapital->getDFLiege() || !getDFLiege())
+	if (!myDuchyCapital || myDuchyCapital->getID() == getID() || !myDuchyCapital->getDFLiege())
 		return;
 
 	// If the title's name is transfering to EU4, make sure it makes sense. Thrace should use Constantinople's name...

--- a/CK3toEU4/Source/CK3World/Titles/Title.h
+++ b/CK3toEU4/Source/CK3World/Titles/Title.h
@@ -115,6 +115,7 @@ class Title: commonItems::parser
 	void setCustomTitle() { customTitle = true; }
 	void setManualNameClaim() { nameClaimed = true; }
 	void pickDisplayName(const std::map<std::string, std::shared_ptr<Title>>& mappings); // Grants one counties name to another during N:1 (or N:M) mappings
+	std::shared_ptr<Title> findDuchyCapital();														 // Only for c_, for now
 	void congregateDFCounties();
 	void congregateDJCounties();
 	void loadGeneratedLiege(const std::pair<std::string, std::shared_ptr<Title>>& liege) { generatedLiege = liege; }

--- a/CK3toEU4/Source/CK3World/Titles/Title.h
+++ b/CK3toEU4/Source/CK3World/Titles/Title.h
@@ -114,8 +114,8 @@ class Title: commonItems::parser
 	void setThePope() { thePope = true; }
 	void setCustomTitle() { customTitle = true; }
 	void setManualNameClaim() { nameClaimed = true; }
-	void pickDisplayName(const std::map<std::string, std::shared_ptr<Title>>& mappings); // Grants one counties name to another during N:1 (or N:M) mappings
-	std::shared_ptr<Title> findDuchyCapital();														 // Only for c_, for now
+	void pickDisplayName(const std::map<std::string, std::shared_ptr<Title>>& possibleTitles); // Grants one county's name to another during N:1/N:M mappings
+	std::shared_ptr<Title> findDuchyCapital();																 // Only for c_, for now
 	void congregateDFCounties();
 	void congregateDJCounties();
 	void loadGeneratedLiege(const std::pair<std::string, std::shared_ptr<Title>>& liege) { generatedLiege = liege; }

--- a/CK3toEU4/Source/CK3World/Titles/Title.h
+++ b/CK3toEU4/Source/CK3World/Titles/Title.h
@@ -48,6 +48,7 @@ class Title: commonItems::parser
 	[[nodiscard]] auto isHRECapital() const { return HRECapital; }
 	[[nodiscard]] auto isCustomTitle() const { return customTitle; }
 	[[nodiscard]] auto isRenamed() const { return renamed; }
+	[[nodiscard]] auto isManualNameClaimed() const { return nameClaimed; }
 	[[nodiscard]] const auto& getName() const { return name; }
 	[[nodiscard]] const auto& getDisplayName() const { return displayName; }
 	[[nodiscard]] const auto& getAdjective() const { return adjective; }
@@ -112,6 +113,8 @@ class Title: commonItems::parser
 	void dropTitleFromDFVassals(long long titleID);
 	void setThePope() { thePope = true; }
 	void setCustomTitle() { customTitle = true; }
+	void setManualNameClaim() { nameClaimed = true; }
+	void overrideDisplayName(std::string newName) { displayName = newName; } // Grants one counties name to another during N:1 (or N:M) mappings
 	void congregateDFCounties();
 	void congregateDJCounties();
 	void loadGeneratedLiege(const std::pair<std::string, std::shared_ptr<Title>>& liege) { generatedLiege = liege; }
@@ -159,7 +162,8 @@ class Title: commonItems::parser
 	bool inHRE = false;
 	bool thePope = false;
 	bool customTitle = false;													// True if title was fromed via "Found a New Kingdom/Empire" decision. Vestigal
-	bool renamed = false;														// True if title was manully named
+	bool renamed = false;														// True if title was manually named
+	bool nameClaimed = false;													// Flag for 1:M (or N:M) province mappings to decide who gets the manual name
 	std::map<std::string, std::shared_ptr<Title>> ownedDFCounties; // used to map higher-lvl titles directly to clay. Includes self! Every c_+ title has this.
 	std::map<std::string, std::shared_ptr<Title>> ownedDJCounties; // ditto
 	std::optional<std::pair<std::string, std::shared_ptr<Title>>> generatedLiege; // Liege we set manually while splitting vassals.

--- a/CK3toEU4/Source/CK3World/Titles/Title.h
+++ b/CK3toEU4/Source/CK3World/Titles/Title.h
@@ -114,7 +114,7 @@ class Title: commonItems::parser
 	void setThePope() { thePope = true; }
 	void setCustomTitle() { customTitle = true; }
 	void setManualNameClaim() { nameClaimed = true; }
-	void overrideDisplayName(std::string newName) { displayName = newName; } // Grants one counties name to another during N:1 (or N:M) mappings
+	void pickDisplayName(const std::map<std::string, std::shared_ptr<Title>>& mappings); // Grants one counties name to another during N:1 (or N:M) mappings
 	void congregateDFCounties();
 	void congregateDJCounties();
 	void loadGeneratedLiege(const std::pair<std::string, std::shared_ptr<Title>>& liege) { generatedLiege = liege; }

--- a/CK3toEU4/Source/CK3World/Titles/Title.h
+++ b/CK3toEU4/Source/CK3World/Titles/Title.h
@@ -47,6 +47,7 @@ class Title: commonItems::parser
 	[[nodiscard]] auto isHolderCapital() const { return holderCapital; }
 	[[nodiscard]] auto isHRECapital() const { return HRECapital; }
 	[[nodiscard]] auto isCustomTitle() const { return customTitle; }
+	[[nodiscard]] auto isRenamed() const { return renamed; }
 	[[nodiscard]] const auto& getName() const { return name; }
 	[[nodiscard]] const auto& getDisplayName() const { return displayName; }
 	[[nodiscard]] const auto& getAdjective() const { return adjective; }
@@ -158,6 +159,7 @@ class Title: commonItems::parser
 	bool inHRE = false;
 	bool thePope = false;
 	bool customTitle = false;													// True if title was fromed via "Found a New Kingdom/Empire" decision. Vestigal
+	bool renamed = false;														// True if title was manully named
 	std::map<std::string, std::shared_ptr<Title>> ownedDFCounties; // used to map higher-lvl titles directly to clay. Includes self! Every c_+ title has this.
 	std::map<std::string, std::shared_ptr<Title>> ownedDJCounties; // ditto
 	std::optional<std::pair<std::string, std::shared_ptr<Title>>> generatedLiege; // Liege we set manually while splitting vassals.

--- a/CK3toEU4/Source/EU4World/EU4World.cpp
+++ b/CK3toEU4/Source/EU4World/EU4World.cpp
@@ -669,17 +669,7 @@ std::optional<std::pair<std::string, std::shared_ptr<CK3::Title>>> EU4::World::d
 		}
 	}
 
-	// If the title's name is transfering to EU4, make sure it makes sense. Thrace should use Constantinople's name...
-	if (toReturn.second->isRenamed())
-	{
-		// ... if they belong to the same owner, Constantinople also has a custom name and they are in the same mapping
-		const auto& myDuchyCapital = toReturn.second->getDJLiege()->second->getCapital().second;
-		if (myDuchyCapital->isRenamed() && ck3Titles.contains(myDuchyCapital->getName()) &&
-			 myDuchyCapital->getDFLiege()->first == toReturn.second->getDFLiege()->first)
-		{
-			toReturn.second->overrideDisplayName(myDuchyCapital->getDisplayName());
-		}
-	}
+	toReturn.second->pickDisplayName(ck3Titles);
 	if (toReturn.first.empty() || !toReturn.second)
 	{
 		return std::nullopt;

--- a/CK3toEU4/Source/EU4World/EU4World.cpp
+++ b/CK3toEU4/Source/EU4World/EU4World.cpp
@@ -557,7 +557,7 @@ void EU4::World::importCK3Provinces(const CK3::World& sourceWorld)
 		else
 		{
 			// And finally, initialize it.
-			province.second->initializeFromCK3Title(sourceProvince->second, cultureMapper, religionMapper);
+			province.second->initializeFromCK3Title(sourceProvince->second, cultureMapper, religionMapper, locDegrader);
 			counter++;
 		}
 	}
@@ -666,6 +666,18 @@ std::optional<std::pair<std::string, std::shared_ptr<CK3::Title>>> EU4::World::d
 		{
 			toReturn = title;
 			maxDev = provinceWeight;
+		}
+	}
+
+	// If the title's name is transfering to EU4, make sure it makes sense. Thrace should use Constantinople's name...
+	if (toReturn.second->isRenamed())
+	{
+		// ... if they belong to the same owner, Constantinople also has a custom name and they are in the same mapping
+		const auto& myDuchyCapital = toReturn.second->getDJLiege()->second->getCapital().second;
+		if (myDuchyCapital->isRenamed() && ck3Titles.contains(myDuchyCapital->getName()) &&
+			 myDuchyCapital->getDFLiege()->first == toReturn.second->getDFLiege()->first)
+		{
+			toReturn.second->overrideDisplayName(myDuchyCapital->getDisplayName());
 		}
 	}
 	if (toReturn.first.empty() || !toReturn.second)

--- a/CK3toEU4/Source/EU4World/Output/outWorld.cpp
+++ b/CK3toEU4/Source/EU4World/Output/outWorld.cpp
@@ -406,13 +406,13 @@ void EU4::World::outputAdvisers(const Configuration& theConfiguration) const
 
 void EU4::World::outputHistoryProvinces(const Configuration& theConfiguration) const
 {
-	for (const auto& province: provinces)
+	for (const auto& province: provinces | std::views::values)
 	{
-		std::ofstream output("output/" + theConfiguration.getOutputName() + "/" + province.second->getHistoryCountryFile());
+		std::ofstream output("output/" + theConfiguration.getOutputName() + "/" + province->getHistoryCountryFile());
 		if (!output.is_open())
 			throw std::runtime_error(
-				 "Could not create country history file: output/" + theConfiguration.getOutputName() + "/" + province.second->getHistoryCountryFile());
-		output << *province.second;
+				 "Could not create country history file: output/" + theConfiguration.getOutputName() + "/" + province->getHistoryCountryFile());
+		output << *province;
 		output.close();
 	}
 }
@@ -492,6 +492,24 @@ void EU4::World::outputLocalization(const Configuration& theConfiguration, bool 
 			spanish << " " << idea.getDynamicName() + suffix[i] << ":0 \"" << idea.getLocalizedName() + " " + spa_ideaText[i] << "\"\n";
 			german << " " << idea.getDynamicName() + suffix[i] << ":0 \"" << idea.getLocalizedName() + " " + ger_ideaText[i] << "\"\n";
 		}
+	}
+
+	// port manually named provinces over from CK3
+	auto userRenamedOnly = [](std::shared_ptr<EU4::Province> p) {
+		return bool(p->isRenamed());
+	};
+
+	for (const auto& province: provinces | std::views::values | std::views::filter(userRenamedOnly))
+	{
+		english << " PROV" << province->getProvinceID() << ":0 \"" << province->getCustomName() << "\"\n";
+		french << " PROV" << province->getProvinceID() << ":0 \"" << province->getCustomName() << "\"\n";
+		spanish << " PROV" << province->getProvinceID() << ":0 \"" << province->getCustomName() << "\"\n";
+		german << " PROV" << province->getProvinceID() << ":0 \"" << province->getCustomName() << "\"\n";
+
+		english << " PROV_ADJ" << province->getProvinceID() << ":0 \"" << province->getCustomName() << "\"\n";
+		french << " PROV_ADJ" << province->getProvinceID() << ":0 \"" << province->getCustomName() << "\"\n";
+		spanish << " PROV_ADJ" << province->getProvinceID() << ":0 \"" << province->getCustomName() << "\"\n";
+		german << " PROV_ADJ" << province->getProvinceID() << ":0 \"" << province->getCustomName() << "\"\n";
 	}
 	english.close();
 	french.close();

--- a/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
+++ b/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
@@ -11,6 +11,11 @@
 #include "../Country/Country.h"
 #include "Log.h"
 
+EU4::Province::Province(const std::shared_ptr<CK3::Title>& origProvince)
+{
+	srcProvince = origProvince;
+}
+
 EU4::Province::Province(int id, const std::string& filePath): provID(id)
 {
 	// Load from a country file, if one exists. Otherwise rely on defaults.
@@ -45,18 +50,7 @@ void EU4::Province::initializeFromCK3Title(const std::shared_ptr<CK3::Title>& or
 	details.controller = tagCountry.first;
 
 	// check for manual CK3 province name
-	if (srcProvince->isRenamed() && !srcProvince->isManualNameClaimed())
-	{
-		auto name = locDegrader.degradeString(srcProvince->getDisplayName());
-		auto win1252name = commonItems::convertUTF8ToWin1252(name);
-		if (!std::any_of(win1252name.begin(), win1252name.end(), [](char c) { // All not latin chars will be squished to 0, lets not transfer those
-				 return c == '0';
-			 }))
-		{
-			details.customName = name;
-			srcProvince->setManualNameClaim(); // For 1:M (or N:M) cases only the first province with a given srcProvince gets the name
-		}
-	}
+
 
 	// History section
 	// Not touching Capital, that's hardcoded English name.
@@ -172,8 +166,20 @@ void EU4::Province::initializeFromCK3Title(const std::shared_ptr<CK3::Title>& or
 	details.vaisyasBurghers = false;	 // No.
 }
 
-void EU4::Province::cul(const mappers::CultureMapper& cultureMapper)
+void EU4::Province::registerManualName(const mappers::LocDegraderMapper& locDegrader)
 {
+	if (srcProvince->isRenamed() && !srcProvince->isManualNameClaimed())
+	{
+		auto name = locDegrader.degradeString(srcProvince->getDisplayName());
+		auto win1252name = commonItems::convertUTF8ToWin1252(name);
+		if (!std::any_of(win1252name.begin(), win1252name.end(), [](char c) { // All not latin chars will be squished to 0, lets not transfer those
+				 return c == '0';
+			 }))
+		{
+			details.customName = name;
+			srcProvince->setManualNameClaim(); // For 1:M (or N:M) cases only the first province with a given srcProvince gets the name
+		}
+	}
 }
 
 void EU4::Province::sterilize()

--- a/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
+++ b/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
@@ -1,4 +1,5 @@
 #include "EU4Province.h"
+#include "../../../../Fronter/commonItems/OSCompatibilityLayer.h"
 #include "../../CK3World/Characters/Character.h"
 #include "../../CK3World/Cultures/Culture.h"
 #include "../../CK3World/Geography/CountyDetail.h"
@@ -47,11 +48,15 @@ void EU4::Province::initializeFromCK3Title(const std::shared_ptr<CK3::Title>& or
 	if (srcProvince->isRenamed() && !srcProvince->isManualNameClaimed())
 	{
 		auto name = locDegrader.degradeString(srcProvince->getDisplayName());
-		details.customName = name;
-		// srcProvince seems to be an instance of "const shared_ptr<T>" and not "const shared_ptr<const T>, so we're using that"
-		srcProvince->setManualNameClaim();
+		auto win1252name = commonItems::convertUTF8ToWin1252(name);
+		if (!std::any_of(win1252name.begin(), win1252name.end(), [](char c) { // All not latin chars will be squised to 0, lets not transfer those
+				 return c == '0';
+			 }))
+		{
+			details.customName = name;
+			srcProvince->setManualNameClaim(); // For 1:M (or N:M) cases only the first province with a given srcProvince gets the name
+		}
 	}
-	mappers::LocDegraderMapper;
 
 	// History section
 	// Not touching Capital, that's hardcoded English name.

--- a/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
+++ b/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
@@ -1,5 +1,4 @@
 #include "EU4Province.h"
-#include "../../../../Fronter/commonItems/OSCompatibilityLayer.h"
 #include "../../CK3World/Characters/Character.h"
 #include "../../CK3World/Cultures/Culture.h"
 #include "../../CK3World/Geography/CountyDetail.h"
@@ -10,6 +9,7 @@
 #include "../../Mappers/ReligionMapper/ReligionMapper.h"
 #include "../Country/Country.h"
 #include "Log.h"
+#include "OSCompatibilityLayer.h"
 
 EU4::Province::Province(const std::shared_ptr<CK3::Title>& origProvince): srcProvince(origProvince)
 {
@@ -47,9 +47,6 @@ void EU4::Province::initializeFromCK3Title(const std::shared_ptr<CK3::Title>& or
 	tagCountry = *srcProvince->getHoldingTitle().second->getEU4Tag(); // linking to our holder
 	details.owner = tagCountry.first;
 	details.controller = tagCountry.first;
-
-	// check for manual CK3 province name
-
 
 	// History section
 	// Not touching Capital, that's hardcoded English name.

--- a/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
+++ b/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
@@ -49,7 +49,7 @@ void EU4::Province::initializeFromCK3Title(const std::shared_ptr<CK3::Title>& or
 	{
 		auto name = locDegrader.degradeString(srcProvince->getDisplayName());
 		auto win1252name = commonItems::convertUTF8ToWin1252(name);
-		if (!std::any_of(win1252name.begin(), win1252name.end(), [](char c) { // All not latin chars will be squised to 0, lets not transfer those
+		if (!std::any_of(win1252name.begin(), win1252name.end(), [](char c) { // All not latin chars will be squished to 0, lets not transfer those
 				 return c == '0';
 			 }))
 		{
@@ -170,6 +170,10 @@ void EU4::Province::initializeFromCK3Title(const std::shared_ptr<CK3::Title>& or
 	details.rajputsNobles = false;	 // nono.
 	details.brahminsChurch = false;	 // Still no.
 	details.vaisyasBurghers = false;	 // No.
+}
+
+void EU4::Province::cul(const mappers::CultureMapper& cultureMapper)
+{
 }
 
 void EU4::Province::sterilize()

--- a/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
+++ b/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
@@ -26,7 +26,8 @@ void EU4::Province::updateWith(const std::string& filePath)
 
 void EU4::Province::initializeFromCK3Title(const std::shared_ptr<CK3::Title>& origProvince,
 	 const mappers::CultureMapper& cultureMapper,
-	 const mappers::ReligionMapper& religionMapper)
+	 const mappers::ReligionMapper& religionMapper,
+	 const mappers::LocDegraderMapper& locDegrader)
 {
 	srcProvince = origProvince;
 
@@ -41,6 +42,16 @@ void EU4::Province::initializeFromCK3Title(const std::shared_ptr<CK3::Title>& or
 	tagCountry = *srcProvince->getHoldingTitle().second->getEU4Tag(); // linking to our holder
 	details.owner = tagCountry.first;
 	details.controller = tagCountry.first;
+
+	// check for manual CK3 province name
+	if (srcProvince->isRenamed() && !srcProvince->isManualNameClaimed())
+	{
+		auto name = locDegrader.degradeString(srcProvince->getDisplayName());
+		details.customName = name;
+		// srcProvince seems to be an instance of "const shared_ptr<T>" and not "const shared_ptr<const T>, so we're using that"
+		srcProvince->setManualNameClaim();
+	}
+	mappers::LocDegraderMapper;
 
 	// History section
 	// Not touching Capital, that's hardcoded English name.

--- a/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
+++ b/CK3toEU4/Source/EU4World/Province/EU4Province.cpp
@@ -11,9 +11,8 @@
 #include "../Country/Country.h"
 #include "Log.h"
 
-EU4::Province::Province(const std::shared_ptr<CK3::Title>& origProvince)
+EU4::Province::Province(const std::shared_ptr<CK3::Title>& origProvince): srcProvince(origProvince)
 {
-	srcProvince = origProvince;
 }
 
 EU4::Province::Province(int id, const std::string& filePath): provID(id)

--- a/CK3toEU4/Source/EU4World/Province/EU4Province.h
+++ b/CK3toEU4/Source/EU4World/Province/EU4Province.h
@@ -1,6 +1,7 @@
 #ifndef EU4_PROVINCE_H
 #define EU4_PROVINCE_H
 
+#include "../../Mappers/LocDegraderMapper/LocDegraderMapper.h"
 #include "ProvinceDetails.h"
 #include <memory>
 #include <string>
@@ -28,7 +29,8 @@ class Province
 	void updateWith(const std::string& filePath);
 	void initializeFromCK3Title(const std::shared_ptr<CK3::Title>& origProvince,
 		 const mappers::CultureMapper& cultureMapper,
-		 const mappers::ReligionMapper& religionMapper);
+		 const mappers::ReligionMapper& religionMapper,
+		 const mappers::LocDegraderMapper& locDegrader);
 
 	[[nodiscard]] const auto& getHistoryCountryFile() const { return historyProvincesFile; }
 	[[nodiscard]] const auto& getTagCountry() const { return tagCountry; }

--- a/CK3toEU4/Source/EU4World/Province/EU4Province.h
+++ b/CK3toEU4/Source/EU4World/Province/EU4Province.h
@@ -23,6 +23,7 @@ class Province
 {
   public:
 	Province() = default;
+	Province(const std::shared_ptr<CK3::Title>& origProvince); // For tests
 
 	Province(int id, const std::string& filePath);
 
@@ -31,7 +32,7 @@ class Province
 		 const mappers::CultureMapper& cultureMapper,
 		 const mappers::ReligionMapper& religionMapper,
 		 const mappers::LocDegraderMapper& locDegrader);
-	void cul(const mappers::CultureMapper& cultureMapper);
+	void registerManualName(const mappers::LocDegraderMapper& locDegrader);
 
 	[[nodiscard]] const auto& getHistoryCountryFile() const { return historyProvincesFile; }
 	[[nodiscard]] const auto& getTagCountry() const { return tagCountry; }

--- a/CK3toEU4/Source/EU4World/Province/EU4Province.h
+++ b/CK3toEU4/Source/EU4World/Province/EU4Province.h
@@ -37,6 +37,8 @@ class Province
 	[[nodiscard]] const auto& getCulture() const { return details.culture; }
 	[[nodiscard]] const auto& getSourceProvince() const { return srcProvince; }
 	[[nodiscard]] const auto& getCenterOfTradeLevel() const { return details.centerOfTrade; }
+	[[nodiscard]] const auto& getCustomName() const { return details.customName.value(); }
+	[[nodiscard]] const bool isRenamed() const { return details.customName.has_value(); }
 	[[nodiscard]] auto getDev() const { return details.baseTax + details.baseProduction + details.baseManpower; }
 	[[nodiscard]] auto getAdm() const { return details.baseTax; }
 	[[nodiscard]] auto getMil() const { return details.baseManpower; }

--- a/CK3toEU4/Source/EU4World/Province/EU4Province.h
+++ b/CK3toEU4/Source/EU4World/Province/EU4Province.h
@@ -31,6 +31,7 @@ class Province
 		 const mappers::CultureMapper& cultureMapper,
 		 const mappers::ReligionMapper& religionMapper,
 		 const mappers::LocDegraderMapper& locDegrader);
+	void cul(const mappers::CultureMapper& cultureMapper);
 
 	[[nodiscard]] const auto& getHistoryCountryFile() const { return historyProvincesFile; }
 	[[nodiscard]] const auto& getTagCountry() const { return tagCountry; }

--- a/CK3toEU4/Source/EU4World/Province/ProvinceDetails.h
+++ b/CK3toEU4/Source/EU4World/Province/ProvinceDetails.h
@@ -47,6 +47,7 @@ class ProvinceDetails: commonItems::parser
 	std::string tradeGoods;
 	std::string estate;
 	std::string datedInfo;
+	std::optional<std::string> customName;
 	std::set<std::string> cores;
 	std::set<std::string> discoveredBy;
 	std::set<std::string> latentGoods;


### PR DESCRIPTION
Have CK3 counties with player overridden names transfer to their associated EU4 provinces in a sensible manner.
Also patch some typos and such in tradition_ideas.txt.