### PR TITLE
Relax restrictions on incoherent dynasty CoAs.

### DIFF
--- a/CK3ToEU4Tests/CK3WorldTests/DynastyTests/DynastiesTests.cpp
+++ b/CK3ToEU4Tests/CK3WorldTests/DynastyTests/DynastiesTests.cpp
@@ -82,7 +82,7 @@ TEST(CK3World_DynastiesTests, coatsCanBeLinked)
 	ASSERT_EQ("lumpy", d2->second->getCoA()->second->getPattern());
 }
 
-TEST(CK3World_DynastiesTests, linkingMissingCoatsThrowsException)
+TEST(CK3World_DynastiesTests, linkingMissingCoatsDoesntLinkAnything)
 {
 	std::stringstream input;
 	input << "13={coat_of_arms_id = 1}\n";
@@ -93,5 +93,11 @@ TEST(CK3World_DynastiesTests, linkingMissingCoatsThrowsException)
 	input2 << "1 = { pattern=\"smooth\"}\n";
 	CK3::CoatsOfArms coats(input2);
 
-	ASSERT_THROW(dynasties.linkCoats(coats), std::runtime_error);
+	dynasties.linkCoats(coats);
+
+	const auto& d1 = dynasties.getDynasties().find(13);
+	const auto& d2 = dynasties.getDynasties().find(15);
+
+	EXPECT_EQ("smooth", d1->second->getCoA()->second->getPattern());
+	EXPECT_FALSE(d2->second->getCoA()->second);
 }

--- a/CK3toEU4/Data_Files/configurables/religion_map.txt
+++ b/CK3toEU4/Data_Files/configurables/religion_map.txt
@@ -20,6 +20,7 @@ link = { eu4 = mahayana ck3 = mahayana }
 link = { eu4 = vajrayana ck3 = vajrayana ck3 = lamaism }
 # Christianity
 link = { eu4 = catholic religious_head = k_papal_state }
+link = { eu4 = catholic ck3 = conversos ck3 = catholic ck3 = insular_celtic } # Fallback for old saves (pre 1.6.1.2)
 link = { eu4 = orthodox religious_head = k_orthodox }
 link = { eu4 = coptic religious_head = d_coptic_papacy }
 link = { eu4 = coptic religious_head = d_apostolic_church }

--- a/CK3toEU4/Source/CK3World/Dynasties/Dynasties.cpp
+++ b/CK3toEU4/Source/CK3World/Dynasties/Dynasties.cpp
@@ -48,8 +48,8 @@ void CK3::Dynasties::linkCoats(const CoatsOfArms& coats)
 		}
 		else
 		{
-			throw std::runtime_error(
-				 "Dynasty " + std::to_string(dynasty.first) + " has CoA " + std::to_string(dynasty.second->getCoA()->first) + " which has no definition!");
+			Log(LogLevel::Warning) << "Dynasty " + std::to_string(dynasty.first) + " has CoA " + std::to_string(dynasty.second->getCoA()->first) +
+													" which has no definition!";
 		}
 	}
 	Log(LogLevel::Info) << "<> " << counter << " dynasties updated.";


### PR DESCRIPTION
- useful when handling incompatible saves.