### PR TITLE
tweaks for configurables

### DIFF
--- a/CK3toEU4/Data_Files/configurables/char_reduce.txt
+++ b/CK3toEU4/Data_Files/configurables/char_reduce.txt
@@ -34,11 +34,21 @@ link = { utf8 = "ș" win1252 = "š" }
 link = { utf8 = "ś" win1252 = "s" }
 link = { utf8 = "ț" win1252 = "t" }
 link = { utf8 = "ź" win1252 = "z" }
-link = { utf8 = "ż" win1252 = "ž" }
+link = { utf8 = "ż" win1252 = "z" } # Mostly used in Polish and simplified to "z"
+link = { utf8 = "ĉ" win1252 = "cx" } # Esperanto support because people are mad
+link = { utf8 = "ĝ" win1252 = "gx" }
+link = { utf8 = "ĥ" win1252 = "hx" }
+link = { utf8 = "ĵ" win1252 = "jx" }
+link = { utf8 = "ŝ" win1252 = "sx" }
 link = { utf8 = "ŭ" win1252 = "û" }
 link = { utf8 = "ġ" win1252 = "gh" } # Fate of Iberia added Burġus as a name
+
 link = { utf8 = "ǝ" win1252 = "ä" }
+
 link = { utf8 = "ṗ" win1252 = "p" }
+
+
+
 link = { utf8 = "ṣ" win1252 = "s" }
 link = { utf8 = "ẹ" win1252 = "e" }
 link = { utf8 = "ọ" win1252 = "o" }
@@ -72,8 +82,14 @@ link = { utf8 = "Ș" win1252 = "Š" }
 link = { utf8 = "Ś" win1252 = "S" }
 link = { utf8 = "Ț" win1252 = "T" }
 link = { utf8 = "Ź" win1252 = "Z" }
-link = { utf8 = "Ż" win1252 = "Ž" }
+link = { utf8 = "Ż" win1252 = "Z" } # Mostly used in Polish and simplified to "Z"
+link = { utf8 = "Ĉ" win1252 = "Cx" } # Esperanto support because people are insane
+link = { utf8 = "Ĝ" win1252 = "Gx" }
+link = { utf8 = "Ĥ" win1252 = "Hx" }
+link = { utf8 = "Ĵ" win1252 = "Jx" }
+link = { utf8 = "Ŝ" win1252 = "Sx" }
 link = { utf8 = "Ŭ" win1252 = "Û" }
+
 link = { utf8 = "Ġ" win1252 = "Gh" }
 link = { utf8 = "Ə" win1252 = "Ä" }
 link = { utf8 = "Ẹ" win1252 = "E" }

--- a/CK3toEU4/Data_Files/configurables/culture_map.txt
+++ b/CK3toEU4/Data_Files/configurables/culture_map.txt
@@ -223,7 +223,7 @@ link = { eu4 = gaulic ck3 = roman tech = western gfx = westerngfx region = franc
 link = { eu4 = theodisc ck3 = roman tech = western gfx = westerngfx region = north_german_region region = south_german_region }
 link = { eu4 = theodisc ck3 = laessin tech = western gfx = westerngfx }
 link = { eu4 = pannonian ck3 = roman tech = western gfx = easterngfx region = carpathia_region }
-link = { eu4 = pannonian ck3 = pannonian ck3 = romano_pannonian gfx = easterngfx tech = western }
+link = { eu4 = pannonian ck3 = romano_pannonian gfx = easterngfx tech = western }
 link = { eu4 = wenedyk ck3 = roman tech = western gfx = easterngfx region = russia_region region = ural_region region = baltic_region region = poland_region region = ruthenia_region region = crimea_region }
 link = { eu4 = wenedyk ck3 = wenedyk tech = western gfx = easterngfx }
 link = { eu4 = britannian ck3 = roman tech = western gfx = westerngfx region = british_isles_region }
@@ -487,7 +487,7 @@ link = { eu4 = sorbian ck3 = serbian tech = western gfx = westerngfx region = no
 link = { eu4 = serbian ck3 = serbian ck3 = abotrite ck3 = branichian ck3 = doclean ck3 = travunian ck3 = zachlumian tech = eastern gfx = easterngfx }
 link = { eu4 = romanian ck3 = vlach ck3 = romano_dacian tech = eastern gfx = easterngfx }
 link = { eu4 = bulgarian ck3 = bulgarian ck3 = berzite ck3 = tracki tech = eastern gfx = easterngfx }
-link = { eu4 = slovene ck3 = carantanian ck3 = blatno_slavic ck3 = dudlebian tech = eastern gfx = easterngfx }
+link = { eu4 = slovene ck3 = carantanian ck3 = blatno_slavic ck3 = pannonian  ck3 = dudlebian tech = eastern gfx = easterngfx }
 link = { eu4 = bosnian ck3 = bosnian tech = eastern gfx = easterngfx }
 
 # Proto-Slavic / Balkan split

--- a/CK3toEU4/Data_Files/configurables/religion_map.txt
+++ b/CK3toEU4/Data_Files/configurables/religion_map.txt
@@ -20,7 +20,7 @@ link = { eu4 = mahayana ck3 = mahayana }
 link = { eu4 = vajrayana ck3 = vajrayana ck3 = lamaism }
 # Christianity
 link = { eu4 = catholic religious_head = k_papal_state }
-link = { eu4 = catholic ck3 = conversos ck3 = catholic ck3 = insular_celtic ck3 = mozarabic_church } # Fallback for old saves (pre 1.6.1.2)
+link = { eu4 = catholic ck3 = conversos ck3 = catholic ck3 = mozarabic_church } # Fallback for old saves (pre 1.6.1.2)
 link = { eu4 = orthodox religious_head = k_orthodox }
 link = { eu4 = coptic religious_head = d_coptic_papacy }
 link = { eu4 = coptic religious_head = d_apostolic_church }
@@ -35,6 +35,7 @@ link = { eu4 = messalian ck3 = messalian }
 link = { eu4 = adamites ck3 = adamites }
 link = { eu4 = bosnian_church ck3 = bosnian_church }
 link = { eu4 = adoptianist ck3 = adoptionist }
+link = { eu4 = insular_celtic ck3 = insular_celtic } # Fallback, it is already defined so let use it 
 # Tani
 link = { eu4 = animism ck3 = donyipoloism ck3 = sedism }
 # Dualism

--- a/CK3toEU4/Data_Files/configurables/tag_mappings.txt
+++ b/CK3toEU4/Data_Files/configurables/tag_mappings.txt
@@ -3,7 +3,7 @@
 # single optional: ck3 = x_title
 # single optional: capitals = { range of EU4provinceIDs }
 # made up example: ck3 = c_vestisland eu4 = VST capitals = { 1 2 }
-# Having a capital defined takes presedence over title. e_mongols would turn into VST if they had a capital in EU4 province 1 or 2.
+# Having a capital defined takes precedence over title. e_mongols would turn into VST if they had a capital in EU4 province 1 or 2.
 
 # Scandinavia
 
@@ -46,7 +46,6 @@ link = { ck3 = c_attica eu4 = ATH }
 link = { ck3 = k_athens eu4 = ATH }
 link = { ck3 = k_bosnia eu4 = BOS }
 link = { ck3 = d_bosna eu4 = BOS }
-#link = { ck3 = d_bosnia eu4 = BOS } This appears in the loc, but doesn't appear in 00_landed_titles?
 link = { ck3 = e_bulgaria eu4 = BUL }
 link = { ck3 = e_bulgarian_empire eu4 = BUL }
 link = { ck3 = k_bulgaria eu4 = BUL }
@@ -249,7 +248,6 @@ link = { ck3 = e_hre_roman eu4 = HLR }
 link = { ck3 = c_cleves eu4 = KLE }
 link = { ck3 = c_cologne eu4 = KOL }
 link = { ck3 = d_germania_inferior eu4 = KOL }
-#link = { ck3 = ??? eu4 = LAU } #No space between Hamburg/Luneburg
 link = { ck3 = d_upper_lorraine eu4 = LOR }
 link = { ck3 = d_lower_lorraine eu4 = LOR }
 link = { ck3 = c_luneburg eu4 = LUN }
@@ -363,8 +361,6 @@ link = { ck3 = c_modena eu4 = MOD }
 link = { ck3 = k_naples eu4 = NAP }
 link = { ck3 = c_napoli eu4 = NAP }
 link = { ck3 = d_campania eu4 = NAP }
-#link = { ck3 = k_papal_state eu4 = PAP } # The papacy is handled internally by the converter.
-#link = { ck3 = d_fraticelli eu4 = FAP } # Set manually within the converter.
 link = { ck3 = c_parma eu4 = PAR }
 link = { ck3 = d_flaminia eu4 = PAR }
 link = { ck3 = k_pisa eu4 = PIS }
@@ -434,8 +430,9 @@ link = { ck3 = d_bulgars eu4 = KAZ }
 link = { ck3 = c_moskva eu4 = MOS }
 link = { ck3 = k_muscovy eu4 = MOS }
 link = { capitals = { 575 } eu4 = MOS } 	
-link = { capitals = { 622 } eu4 = NOG } # Ak-Dzulpas -> Nogai
 link = { ck3 = k_nogai eu4 = NOG }
+link = { ck3 = k_kimek eu4 = NOG }
+link = { ck3 = k_zhetysu eu4 = SHY }
 link = { ck3 = d_jemba eu4 = NOG }
 link = { ck3 = k_novgorod eu4 = NOV }
 link = { ck3 = d_novgorod eu4 = NOV }
@@ -455,7 +452,7 @@ link = { ck3 = e_russian_empire eu4 = RUS }
 link = { ck3 = d_ryazan eu4 = RYA }
 link = { ck3 = c_ryazan eu4 = RYA }
 link = { ck3 = c_tver eu4 = TVE }
-link = { ck3 = k_opolye eu4 = RUS }
+link = { ck3 = k_opolye eu4 = MOS } #Close enough
 link = { ck3 = k_uzbek eu4 = SHY }
 link = { ck3 = c_yaroslavl eu4 = YAR }
 link = { ck3 = d_yedisan eu4 = ZAZ }
@@ -765,16 +762,13 @@ link = { ck3 = c_kaski eu4 = GRK } #Has city of Gorkha
 link = { ck3 = k_gujarat eu4 = GUJ }
 link = { ck3 = c_gwalior eu4 = GWA }
 link = { ck3 = c_kota eu4 = HAD }
-#link = { ck3 = ??? eu4 = HIN } #Hindustan is Islamic, you can only form e_india as a dharmist
 link = { ck3 = c_mohadavasaka eu4 = IDR } # Has city of Idar
-#link = { ck3 = ??? eu4 = JAJ } #Outside of CK3 scope, appears by event in EU4
 link = { ck3 = d_jangladesh eu4 = JAN }
 link = { ck3 = c_jaffna eu4 = JFN }
 link = { ck3 = c_somnath eu4 = JGD } #Approximate location of Junagarh
 link = { ck3 = c_sarasvata_mandala eu4 = JLV } #Approximate location of the 1090 A.D Zalawad version
 link = { ck3 = c_jumla eu4 = JML }
 link = { ck3 = c_jaunpur eu4 = JNP }
-#link = { ck3 = ??? eu4 = JPR }
 link = { ck3 = c_ludrava eu4 = JSL }
 link = { ck3 = c_dimapur eu4 = KAC }
 link = { ck3 = c_kutch eu4 = KAT }
@@ -785,7 +779,7 @@ link = { ck3 = c_khijjingakota eu4 = KJH }
 link = { ck3 = c_cakrakuta eu4 = KLH }
 link = { ck3 = c_mahishaka eu4 = KLN } #There is another county with a Keladi barony, but I THINK that this county is actually the right place based on comparison with other locations
 link = { ck3 = c_kalpi eu4 = KLP }
-#link = { ck3 = c_alupa eu4 = KLT } #Should be in c_alupa, but MAB had first dibs
+link = { ck3 = c_alupa eu4 = KLT } #MAB is something else now so this returns
 link = { ck3 = c_kumaon eu4 = KMN }
 link = { ck3 = c_kali_kumaon eu4 = KMN }
 link = { ck3 = d_kamarupanagara eu4 = KMT }
@@ -810,7 +804,7 @@ link = { ck3 = c_mallabhum eu4 = MBL } #Has barony of Bisnupur
 link = { ck3 = d_medapata eu4 = MER } #Old name of Mewar
 link = { ck3 = c_medapata eu4 = MER }
 link = { ck3 = d_mathura eu4 = MEW } #Corresponds largely with the area of Mewat
-#link = { ck3 = c_bhaktapur eu4 = MKP } #Should be in c_kathmandu, but KTU has dibs
+link = { ck3 = c_bhaktapur eu4 = MKP } #not kathmandu
 link = { ck3 = c_manipur eu4 = MLB }
 link = { ck3 = k_malwa eu4 = MLW }
 link = { ck3 = d_multan eu4 = MUL }
@@ -828,7 +822,6 @@ link = { ck3 = d_kanyakubja eu4 = ODH } #Roughly corresponds with the Oudh regio
 link = { ck3 = c_lakhnau eu4 = ODH }
 link = { ck3 = k_orissa eu4 = ORI }
 link = { ck3 = c_kalanjara eu4 = PAN } #Kalinjar in EU4
-#link = { ck3 = ??? eu4 = PTA } #Patiala is out of CK3's scope
 link = { ck3 = c_valabhi eu4 = PTL } #Approximate location of the 1194 A.D Version
 link = { ck3 = c_sripuri eu4 = PTT } #Approximate location of Patna
 link = { ck3 = k_punjab eu4 = PUN }
@@ -845,7 +838,6 @@ link = { ck3 = c_daramdin eu4 = SKK } #Approximate location of Sikkim, based on 
 link = { ck3 = k_sindh eu4 = SND }
 link = { ck3 = c_tummana eu4 = SRG }
 link = { ck3 = c_sthanisvara eu4 = SRH }
-#link = { ck3 = ??? eu4 = SRM } #Should be in c_sthanisvara, but SRH has dibs
 link = { ck3 = k_telingana eu4 = TLG }
 link = { ck3 = c_cholamandalam eu4 = TNJ } #Has city of Tanjavur
 link = { ck3 = c_karmanta eu4 = TPR } #Has temple-city of Tripura
@@ -870,7 +862,7 @@ link = { ck3 = c_nizhny_novgorod eu4 = NZH }
 link = { ck3 = d_smolensk eu4 = SMO }
 link = { ck3 = c_smolensk eu4 = SMO }
 
-#link = { ck3 = ??? eu4 = MUG } # Impossible to map Mughal Empire
+link = { ck3 = e_rajastan eu4 = MUG } # Impossible to map Mughal Empire, but this is as close as you can get.
 
 #African Additions
 
@@ -932,12 +924,11 @@ link = { ck3 = k_buryatia eu4 = BRT }
 
 # 1.30 mappings (Not in Tag alphabetical like the rest)
 link = { ck3 = c_munchen eu4 = UBV }
-#link = { ck3 = ??? eu4 = LBV } # Landshut
+link = { ck3 = c_geisenhausen eu4 = LBV } # Landshut
 link = { ck3 = c_ingolstadt eu4 = ING } # Ingolstadt
 link = { ck3 = c_passau eu4 = PSS } # Passau
-#link = { ck3 = ??? eu4 = MBZ } # Should be in c_ravensburg, but RVA had first dibs
 link = { ck3 = c_sankt_gallen eu4 = KNZ } #Has barony Konstanz
-#link = { ck3 = c_rothenburg eu4 = ROT } #PDX put it in the wrong spot? (It's not next to Ansbach?)
+link = { ck3 = c_rothenburg eu4 = ROT } #PDX put it in the wrong spot? (It's not next to Ansbach?)
 link = { ck3 = c_leuchtenburg eu4 = BYT } #Has city of Bayreuth
 link = { ck3 = c_regensburg eu4 = REG } # Regensburg
 link = { ck3 = c_geneva eu4 = GNV } # Geneva
@@ -970,7 +961,6 @@ link = { ck3 = c_bamberg eu4 = BAM }
 link = { ck3 = c_ruppin eu4 = RUP }
 link = { ck3 = c_lippe eu4 = LPP }
 link = { ck3 = c_paderborn eu4 = PAD }
-#link = { ck3 = ??? eu4 = CLB } # Calenberg
 link = { ck3 = c_nordlingen eu4 = DWT } # I think this is ~where Donauwörth is, iffy mapping
 link = { ck3 = c_osnabruck eu4 = OSN }
 link = { ck3 = d_verona eu4 = VRN }
@@ -1008,12 +998,10 @@ link = { ck3 = d_knights_templar eu4 = TEM }
 #Added By Mod Team - special flavor
 
 link = { ck3 = d_saint_addai eu4 = ADD }
-#link = { ck3 = ??? eu4 = AOL } # Army of the Light
 link = { ck3 = d_bektashi eu4 = BEK }
 link = { ck3 = d_holy_sepulchre eu4 = BHS }
 link = { ck3 = d_bulls_rishabha eu4 = BOR }
 link = { ck3 = d_ashokas_chosen eu4 = COA }
-#link = { ck3 = ??? eu4 = COD } # Dralha's Children
 link = { ck3 = d_huitzilopochtli eu4 = COH } # Huitzilopochtli
 link = { ck3 = d_chosen_perkunas eu4 = COP }
 link = { ck3 = d_followers_arjuna eu4 = FOA }
@@ -1023,20 +1011,17 @@ link = { ck3 = d_knights_calatrava eu4 = KCL }
 link = { ck3 = d_knights_santiago eu4 = KOS }
 link = { ck3 = d_zun_warriors eu4 = KOZ }
 link = { ck3 = d_sky_lords eu4 = LOS }
-#link = { ck3 = ??? eu4 = MYM } # Myrmidons
 link = { ck3 = d_saint_anthony eu4 = OOA }
 link = { ck3 = d_spirit_guardians eu4 = SGD }
 link = { ck3 = d_sons_kaleva eu4 = SKL }
 link = { ck3 = d_warriors_perun eu4 = WOP }
 link = { ck3 = d_zealots eu4 = ZLT }
-#link = { ck3 = ??? eu4 = FAP } # Fraticelli Papacy
 
 # Mod: Sunset Invasion
 link = { ck3 = e_nahua eu4 = AZT }
 
 # Some more things
 link = { ck3 = k_daneland eu4 = DNL } # Daneland
-# link = { ck3 = k_danelaw eu4 = DNL } # Danelaw - skipped because DNL is here just for a cultural shenanigan
 link = { ck3 = k_mordvinia eu4 = MDV } # Mordvinia
 link = { ck3 = d_mordvinia eu4 = MDV } # Mordvinia
 link = { ck3 = k_pechenegs eu4 = PTZ } # Pechenegs
@@ -1168,13 +1153,6 @@ link = { ck3 = k_outer_ajuraan eu4 = OGD } # Ogaaden
 link = { ck3 = d_shabelle eu4 = OGD } # Ogaaden
 link = { ck3 = c_gidaya eu4 = OGD } # Ogaaden
 link = { ck3 = c_ganale eu4 = OGD } # Ogaaden
-
-#Tabbed out of PDX 00_countries.txt
-#link = { ck3 = d_kebbi eu4 = KBI } # Kebbi
-#link = { ck3 = c_kebbi eu4 = KBI } # Kebbi
-#link = { ck3 = d_gobir eu4 = GOB } # Gobir
-#link = { ck3 = c_gobir eu4 = GOB } # Gobir
-#link = { ck3 = c_daura eu4 = DAU } # Daura
 
 
 link = { ck3 = k_bjarmaland eu4 = BJA }


### PR DESCRIPTION
removed out-commented tags for slimmer file size, un-uncommented some mappings, slavic pannonians to carantanians, insular to insular as a fallback, Ż to Z instead of Ž because ż is mostly Polish and usually simplified to z in English.