### PR TITLE
Extreme dev situations

### DIFF
--- a/CK3toEU4/Source/EU4World/EU4World.cpp
+++ b/CK3toEU4/Source/EU4World/EU4World.cpp
@@ -785,11 +785,17 @@ double EU4::World::calculateProvinceDevFactor(const std::shared_ptr<Province>& p
 	else if (targetProvinces > 3)
 		modFactor = 0.6;
 	else if (sourceProvinces == 2)
-		modFactor = 0.9;
+		modFactor = 0.91;
 	else if (sourceProvinces == 3)
-		modFactor = 0.81;
-	else if (sourceProvinces > 3)
-		modFactor = 0.72;
+		modFactor = 0.83;
+	else if (sourceProvinces == 4)
+		modFactor = 0.76;
+	else if (sourceProvinces == 5)
+		modFactor = 0.7;
+	else if (sourceProvinces == 6)
+		modFactor = 0.65;
+	else if (sourceProvinces > 6)
+		modFactor = 0.61;
 
 	return modFactor;
 }


### PR DESCRIPTION
Provinces in Tibet, Karelia and Mongolia merge from a ton of provinces, this can cause provinces in eu4 to have far too much development to be good for the game, this solves this issue.