### PR TITLE
Update victoria3_religion_tenets.txt

### DIFF
--- a/CK3ToEU4/Data_Files/configurables/victoria3_religion_tenets.txt
+++ b/CK3ToEU4/Data_Files/configurables/victoria3_religion_tenets.txt
@@ -10,27 +10,38 @@
 link = { eu4religiongroup = christian traits = christian }
 link = { eu4religiongroup = muslim traits = muslim taboos = liquor taboos = wine }
 link = { eu4religiongroup = jewish_group traits = jewish }
-link = { eu4religiongroup = zoroastrian_group traits = eastern traits = mazdan }
+link = { eu4religiongroup = zoroastrian_group traits = mazdan }
+link = { eu4religiongroup = gnostic traits = gnostic }
+link = { eu4religiongroup = yazidism traits = yazidi }
 link = { eu4religiongroup = dharmic eu4religiongroup = eastern traits = eastern }
 link = { eu4religiongroup = pagan traits = animist }
 link = { tenet = tenet_christian_syncretism traits = christian }
+link = { doctrine = tenet_christian_syncretism traits = christian }
 link = { tenet = tenet_islamic_syncretism traits = muslim taboos = liquor taboos = wine }
+link = { doctrine = tenet_islamic_syncretism traits = muslim taboos = liquor taboos = wine }
 link = { tenet = tenet_jewish_syncretism traits = jewish }
+link = { doctrine = tenet_jewish_syncretism traits = jewish }
 link = { tenet = tenet_eastern_syncretism traits = eastern }
+link = { doctrine = tenet_eastern_syncretism traits = eastern }
 link = { tenet = tenet_unreformed_syncretism traits = animist }
+link = { doctrine = tenet_unreformed_syncretism traits = animist }
+link = { tenet = tenet_gnosticism traits = gnostic }
 link = { faith = orthodox faith = iconoclast faith = bogomilist faith = paulician faith = bosnian_church traits = orthodoxy }
+link = { faith = cathar faith = waldensian faith = lollard traits = proto_protestant }
 link = { faith = coptic faith = armenian_apostolic traits = coptic }
 link = { faith = vaishnavism faith = advaitism faith = shaivism faith = srikula_shaktism faith = kalikula_shaktism faith = smartism faith = krishnaism faith = munda_pagan traits = hindu taboos = meat }
 link = { faith = theravada faith = ari faith = mahayana faith = vajrayana faith = lamaism traits = buddhist }
-link = { doctrine = special_doctrine_is_gnostic_faith traits = gnostic }
+link = { doctrine = muhammad_succession_sunni_doctrine traits = sunni_branch }
+link = { doctrine = muhammad_succession_shia_doctrine traits = shiite_branch }
 link = { doctrine = doctrine_gender_equal traits = feminist }
 link = { doctrine = doctrine_pluralism_pluralistic traits = tolerant }
-link = { doctrine = doctrine_consanguinity_unrestricted traits = incestuous }
+link = { doctrine = doctrine_consanguinity_unrestricted doctrine = tenet_divine_marriage traits = incestuous }
 link = { tenet = tenet_aniconism traits = iconoclast taboos = fine_art }
 link = { tenet = tenet_vows_of_poverty traits = egalitarian }
 link = { tenet = tenet_pacifism tenet = tenet_dharmic_pacifism traits = pacifist taboos = fish taboos = meat }
 link = { tenet = tenet_natural_primitivism traits = nudist taboos = clothes taboos = luxury_clothes }
-link = { doctrine = special_doctrine_naked_priests traits = nudist taboos = luxury_clothes }
+link = { doctrine = doctrine_mz_full_nudity traits = nudist taboos = clothes taboos = luxury_clothes }
+link = { doctrine = special_doctrine_naked_priests traits = nudist_clerical taboos = luxury_clothes }
 link = { tenet = tenet_pursuit_of_power traits = meritocratic }
 link = { tenet = tenet_pastoral_isolation traits = pastoralist }
 link = { tenet = tenet_legalism tenet = tenet_religious_legal_pronouncements traits = legalist }


### PR DESCRIPTION
Custom faiths with the Sunni Muhammad succession doctrine will get the sunni_branch trait, so their devout will get be named Sunni Ulema in Vicky3
Custom faiths with the Shia Muhammad succession doctrine will get the shiite_branch trait, so their devout will get be named Shia Ulema in Vicky3
Zoroastrians no longer considered eastern by default
Gnostics are gnostic & Yazidis are yazidi
Cathars, Waldensians, Lollards, & custom faiths that have one of them as a parent get the proto_protestant traits, so their devout will qualify for unique Protestant-only names in Vicky3
Added support for Tenets to Doctrines mod