### PR TITLE
Fixed Stratocratic monarchy.

### DIFF
--- a/CK3ToEU4/Data_Files/blankMod/output/common/government_reforms/ZZZ_enhanced_converter_reforms_feudal.txt
+++ b/CK3ToEU4/Data_Files/blankMod/output/common/government_reforms/ZZZ_enhanced_converter_reforms_feudal.txt
@@ -147,9 +147,7 @@ prussian_monarchy = {
 				}
 				NOT = { map_setup = map_setup_random }
 			}
-			has_unlocked_government_reform = {
-				government_reform = prussian_monarchy
-			}
+			has_unlocked_government_reform = { government_reform = prussian_monarchy }
 			has_reform = prussian_monarchy
 			have_had_reform = prussian_monarchy
 		}
@@ -158,9 +156,7 @@ prussian_monarchy = {
 		OR = {
 			uses_church_aspects = yes
 			uses_fervor = yes
-			has_unlocked_government_reform_tooltip = {
-				government_reform = prussian_monarchy
-			}
+			has_unlocked_government_reform = { government_reform = prussian_monarchy }
 		}
 	}
 	legacy_equivalent = prussian_monarchy_legacy
@@ -236,9 +232,7 @@ prussian_monarchy_base = {
 					have_had_reform = prussian_theocratic_reform
 				}
 			}
-			has_unlocked_government_reform = {
-				government_reform = prussian_monarchy_base
-			}
+			has_unlocked_government_reform = { government_reform = prussian_monarchy_base }
 		}
 	}
 	trigger = {
@@ -256,9 +250,7 @@ prussian_monarchy_base = {
 					have_had_reform = prussian_theocratic_reform
 				}
 			}
-			has_unlocked_government_reform_tooltip = {
-				government_reform = prussian_monarchy_base
-			}
+			has_unlocked_government_reform = { government_reform = prussian_monarchy_base }
 		}
 	}
 	valid_for_nation_designer = yes

--- a/CK3ToEU4/Data_Files/blankMod/output/common/government_reforms/ZZZ_enhanced_converter_reforms_feudal.txt
+++ b/CK3ToEU4/Data_Files/blankMod/output/common/government_reforms/ZZZ_enhanced_converter_reforms_feudal.txt
@@ -147,7 +147,7 @@ prussian_monarchy = {
 				}
 				NOT = { map_setup = map_setup_random }
 			}
-			has_unlocked_government_reform = { government_reform = prussian_monarchy}
+			has_unlocked_government_reform = { government_reform = prussian_monarchy }
 			has_reform = prussian_monarchy
 			have_had_reform = prussian_monarchy
 		}
@@ -252,7 +252,7 @@ prussian_monarchy_base = {
 					have_had_reform = prussian_theocratic_reform
 				}
 			}
-			has_unlocked_government_reform_tooltip = {
+			has_unlocked_government_reform = {
 				government_reform = prussian_monarchy_base
 			}
 		}

--- a/CK3ToEU4/Data_Files/blankMod/output/common/government_reforms/ZZZ_enhanced_converter_reforms_feudal.txt
+++ b/CK3ToEU4/Data_Files/blankMod/output/common/government_reforms/ZZZ_enhanced_converter_reforms_feudal.txt
@@ -147,7 +147,7 @@ prussian_monarchy = {
 				}
 				NOT = { map_setup = map_setup_random }
 			}
-			has_unlocked_government_reform = { government_reform = prussian_monarchy }
+			has_unlocked_government_reform = { government_reform = prussian_monarchy}
 			has_reform = prussian_monarchy
 			have_had_reform = prussian_monarchy
 		}
@@ -232,7 +232,9 @@ prussian_monarchy_base = {
 					have_had_reform = prussian_theocratic_reform
 				}
 			}
-			has_unlocked_government_reform = { government_reform = prussian_monarchy_base }
+			has_unlocked_government_reform = {
+				government_reform = prussian_monarchy_base
+			}
 		}
 	}
 	trigger = {
@@ -250,7 +252,9 @@ prussian_monarchy_base = {
 					have_had_reform = prussian_theocratic_reform
 				}
 			}
-			has_unlocked_government_reform = { government_reform = prussian_monarchy_base }
+			has_unlocked_government_reform_tooltip = {
+				government_reform = prussian_monarchy_base
+			}
 		}
 	}
 	valid_for_nation_designer = yes


### PR DESCRIPTION
Fixed Stratocratic monarchy government reform not giving any modifiers or mechanics with Dominion DLC enabled.

This also fixed the base game decision "form Kingdom of Prussia" to give the correct modifiers and militarization mechanic with Domination both enabled and disabled 

Note that with Dominion disabled the prussian_monarchy_base government reform still does not work but I couldnt figure out a fix for it. I suggest someone smarter takes a look.